### PR TITLE
KM módulo: caso OTROS (actividades SCOT)

### DIFF
--- a/acciones_importar.php
+++ b/acciones_importar.php
@@ -1,5 +1,7 @@
 <?php
 include 'conn.php';
+require_once __DIR__ . '/reportes/importar_otros.php'; // define importarOtros() sin ejecutar su CLI
+require_once __DIR__ . '/calcular_ruta.php';           // define reconciliarKmPendientes() sin ejecutar el endpoint
 header('Content-Type: application/json');
 mysqli_set_charset($conn, "utf8mb4");
 date_default_timezone_set('America/Mexico_City');
@@ -59,37 +61,40 @@ if ($accion === 'ejecutar') {
 
     $inicio = microtime(true);
 
-    $campos = ['ventas', 'tiempo_sitio', 'sin_tiempo'];
-    foreach ($campos as $c) {
-        if (!isset($_FILES[$c]) || $_FILES[$c]['error'] !== UPLOAD_ERR_OK) {
-            echo json_encode(['success' => false, 'error' => "Falta archivo: $c"]);
-            exit;
-        }
-        $ext = strtolower(pathinfo($_FILES[$c]['name'], PATHINFO_EXTENSION));
-        if ($ext !== 'csv') {
-            echo json_encode(['success' => false, 'error' => "Archivo $c no es .csv"]);
-            exit;
-        }
-    }
-
-    // Guardar archivos con nombre canonico (sobreescribe la version anterior)
+    // Cada archivo es opcional; se requiere al menos uno (incluido 'otros').
     $dirReportes = __DIR__ . DIRECTORY_SEPARATOR . 'reportes';
     if (!is_dir($dirReportes)) mkdir($dirReportes, 0777, true);
 
     $stamp = date('Ymd_His');
-    $destinos = [
-        'ventas'       => "$dirReportes/VENTAS_$stamp.csv",
-        'tiempo_sitio' => "$dirReportes/DETALLE-TIEMPO-SITIO_$stamp.csv",
-        'sin_tiempo'   => "$dirReportes/DETALLE-SIN-TIEMPO_$stamp.csv",
+    $mapaNombres = [
+        'ventas'       => "VENTAS_$stamp.csv",
+        'tiempo_sitio' => "DETALLE-TIEMPO-SITIO_$stamp.csv",
+        'sin_tiempo'   => "DETALLE-SIN-TIEMPO_$stamp.csv",
+        'otros'        => "DETALLE-OTROS_$stamp.csv",
     ];
 
-    foreach ($destinos as $key => $ruta) {
-        if (!move_uploaded_file($_FILES[$key]['tmp_name'], $ruta)) {
-            echo json_encode(['success' => false, 'error' => "No se pudo guardar $key"]);
+    $destinos = [];
+    foreach ($mapaNombres as $campo => $nombre) {
+        if (!isset($_FILES[$campo]) || $_FILES[$campo]['error'] !== UPLOAD_ERR_OK) continue;
+        $ext = strtolower(pathinfo($_FILES[$campo]['name'], PATHINFO_EXTENSION));
+        if ($ext !== 'csv') {
+            echo json_encode(['success' => false, 'error' => "Archivo $campo no es .csv"]);
             exit;
         }
+        $ruta = "$dirReportes/$nombre";
+        if (!move_uploaded_file($_FILES[$campo]['tmp_name'], $ruta)) {
+            echo json_encode(['success' => false, 'error' => "No se pudo guardar $campo"]);
+            exit;
+        }
+        $destinos[$campo] = $ruta;
     }
 
+    if (empty($destinos)) {
+        echo json_encode(['success' => false, 'error' => 'Sube al menos un archivo CSV.']);
+        exit;
+    }
+
+    $rutaOtros = $destinos['otros'] ?? null;
     $separador = ',';
 
     // Crear tablas si no existen (igual que el script CLI)
@@ -115,46 +120,46 @@ if ($accion === 'ejecutar') {
         ];
 
         // --- OV (VENTAS) ---
-        $stmtOV = $conn->prepare("INSERT IGNORE INTO OV (OV, id_cliente) VALUES (?, ?)");
-        $r = importarCsvWeb($destinos['ventas'], $separador, function ($datos) use ($stmtOV) {
-            $ov         = isset($datos[11]) ? trim($datos[11]) : '';
-            $id_cliente = isset($datos[1])  ? trim($datos[1])  : '';
-            if ($ov === '') return false;
-            $stmtOV->bind_param("ss", $ov, $id_cliente);
-            return $stmtOV->execute();
-        }, $conn);
-        $stmtOV->close();
-        $resumen['ov_ok']  = $r['ok'];
-        $resumen['ov_err'] = $r['err'];
+        if (isset($destinos['ventas'])) {
+            $stmtOV = $conn->prepare("INSERT IGNORE INTO OV (OV, id_cliente) VALUES (?, ?)");
+            $r = importarCsvWeb($destinos['ventas'], $separador, function ($datos) use ($stmtOV) {
+                $ov         = isset($datos[11]) ? trim($datos[11]) : '';
+                $id_cliente = isset($datos[1])  ? trim($datos[1])  : '';
+                if ($ov === '') return false;
+                $stmtOV->bind_param("ss", $ov, $id_cliente);
+                return $stmtOV->execute();
+            }, $conn);
+            $stmtOV->close();
+            $resumen['ov_ok']  = $r['ok'];
+            $resumen['ov_err'] = $r['err'];
+        }
 
-        // --- OT (DETALLE-TIEMPO-SITIO) ---
-        $stmtOT = $conn->prepare("INSERT INTO OT (OT, id_cliente) VALUES (?, ?)
-            ON DUPLICATE KEY UPDATE id_cliente = VALUES(id_cliente)");
-        $r = importarCsvWeb($destinos['tiempo_sitio'], $separador, function ($datos) use ($stmtOT) {
-            $id_cliente = isset($datos[12]) ? trim($datos[12]) : '';
-            $oType      = isset($datos[13]) ? trim($datos[13]) : '';
-            $pos = strpos($oType, '_');
-            $ot  = $pos !== false ? substr($oType, 0, $pos) : $oType;
-            if ($ot === '') return false;
-            $stmtOT->bind_param("ss", $ot, $id_cliente);
-            return $stmtOT->execute();
-        }, $conn);
-        $resumen['ot_ts_ok']  = $r['ok'];
-        $resumen['ot_ts_err'] = $r['err'];
+        // --- OT (DETALLE-TIEMPO-SITIO / DETALLE-SIN-TIEMPO) ---
+        if (isset($destinos['tiempo_sitio']) || isset($destinos['sin_tiempo'])) {
+            $stmtOT = $conn->prepare("INSERT INTO OT (OT, id_cliente) VALUES (?, ?)
+                ON DUPLICATE KEY UPDATE id_cliente = VALUES(id_cliente)");
+            $cbOT = function ($datos) use ($stmtOT) {
+                $id_cliente = isset($datos[12]) ? trim($datos[12]) : '';
+                $oType      = isset($datos[13]) ? trim($datos[13]) : '';
+                $pos = strpos($oType, '_');
+                $ot  = $pos !== false ? substr($oType, 0, $pos) : $oType;
+                if ($ot === '') return false;
+                $stmtOT->bind_param("ss", $ot, $id_cliente);
+                return $stmtOT->execute();
+            };
 
-        // --- OT (DETALLE-SIN-TIEMPO) ---
-        $r = importarCsvWeb($destinos['sin_tiempo'], $separador, function ($datos) use ($stmtOT) {
-            $id_cliente = isset($datos[12]) ? trim($datos[12]) : '';
-            $oType      = isset($datos[13]) ? trim($datos[13]) : '';
-            $pos = strpos($oType, '_');
-            $ot  = $pos !== false ? substr($oType, 0, $pos) : $oType;
-            if ($ot === '') return false;
-            $stmtOT->bind_param("ss", $ot, $id_cliente);
-            return $stmtOT->execute();
-        }, $conn);
-        $stmtOT->close();
-        $resumen['ot_st_ok']  = $r['ok'];
-        $resumen['ot_st_err'] = $r['err'];
+            if (isset($destinos['tiempo_sitio'])) {
+                $r = importarCsvWeb($destinos['tiempo_sitio'], $separador, $cbOT, $conn);
+                $resumen['ot_ts_ok']  = $r['ok'];
+                $resumen['ot_ts_err'] = $r['err'];
+            }
+            if (isset($destinos['sin_tiempo'])) {
+                $r = importarCsvWeb($destinos['sin_tiempo'], $separador, $cbOT, $conn);
+                $resumen['ot_st_ok']  = $r['ok'];
+                $resumen['ot_st_err'] = $r['err'];
+            }
+            $stmtOT->close();
+        }
 
     } catch (Throwable $e) {
         echo json_encode(['success' => false, 'error' => 'Error en importacion: ' . $e->getMessage()]);
@@ -168,6 +173,25 @@ if ($accion === 'ejecutar') {
             $resumen['geo'] = geocodificarClientesNuevos($conn);
         } catch (Throwable $e) {
             $resumen['geo'] = ['error' => $e->getMessage(), 'ok' => 0, 'cp' => 0, 'err' => 0];
+        }
+    }
+
+    // --- Importar Actividades (OTROS) a la tabla `otros` ---
+    // El km en vivo se calcula al hacer check-in por QR (calcular_ruta.php). Aquí,
+    // tras importar, se reconcilian los check-ins que quedaron sin km porque la
+    // actividad se subió después.
+    $resumen['otros'] = null;
+    $resumen['reconciliacion'] = null;
+    if ($rutaOtros !== null) {
+        try {
+            $resumen['otros'] = importarOtros($conn, $rutaOtros);
+        } catch (Throwable $e) {
+            $resumen['otros'] = ['error' => $e->getMessage(), 'ok' => 0, 'ignoradas' => 0, 'dup' => 0, 'err' => 0];
+        }
+        try {
+            $resumen['reconciliacion'] = reconciliarKmPendientes($conn);
+        } catch (Throwable $e) {
+            $resumen['reconciliacion'] = ['error' => $e->getMessage()];
         }
     }
 

--- a/acciones_kilometraje.php
+++ b/acciones_kilometraje.php
@@ -1,8 +1,25 @@
 <?php
 include 'conn.php';
+require_once __DIR__ . '/calcular_ruta.php'; // define procesarKmCheckin() sin ejecutar el endpoint
 header('Content-Type: application/json');
 mysqli_set_charset($conn, "utf8mb4");
 date_default_timezone_set('America/Mexico_City');
+
+// Calcula el km de un check-in del modal global. Origen = GPS capturado en
+// `coordenadas` ("lat, lng"); destino = actividad OTROS del día o cliente OV/OT.
+// Síncrono (no async) porque el front redirige tras el éxito y mataría la
+// petición. Se envuelve en try/catch para no romper el check-in si falla.
+function calcularKmCheckinGlobal(mysqli $conn, ?string $coordenadas, ?string $ovOt, $idActividad): void {
+    try {
+        $p    = array_map('trim', explode(',', (string) $coordenadas));
+        $oLat = isset($p[0]) && $p[0] !== '' ? floatval($p[0]) : null;
+        $oLng = isset($p[1]) && $p[1] !== '' ? floatval($p[1]) : null;
+        $idUsuario = intval($_COOKIE['id_usuarioL'] ?? $_COOKIE['id_usuario'] ?? 0) ?: null;
+        if ($oLat !== null && $oLng !== null && intval($idActividad) > 0) {
+            procesarKmCheckin($conn, (string) $ovOt, $oLat, $oLng, $idUsuario, intval($idActividad), date('Y-m-d H:i:s'));
+        }
+    } catch (Throwable $e) { /* el cálculo de km nunca debe tumbar el check-in */ }
+}
 
 // Obtener datos del POST
 $id_vehiculo = isset($_POST['vehiculoAsignado']) ? $_POST['vehiculoAsignado'] : null;
@@ -175,7 +192,10 @@ if($accion == 'CapturaCheckIn'){
                 //exit;
             }
 
-        echo json_encode(['status' => 'success', 'message' => 'Check-in realizado correctamente.']);
+            // Calcular km recorrido de este check-in (origen GPS -> destino actividad/cliente)
+            calcularKmCheckinGlobal($conn, $coordenadas, $otRelacionada, $idUltimaActividad);
+
+        echo json_encode(['status' => 'success', 'message' => 'Check-in realizado correctamente.', 'id_actividad' => $idUltimaActividad]);
     } else {
         echo json_encode(['status' => 'error', 'message' => 'Error al realizar el check-in: ' . $conn->error]);
     }
@@ -188,7 +208,6 @@ if($accion == 'CapturaCheckOut'){
             VALUES ('$id_prestamo', '$id_vehiculo', '".$_COOKIE['id_usuario']."', '$km_inicio', '$ruta_destino_inicio', NOW(), 'FINALIZACION', '$notas', '$patron', '$gasActual', '$otRelacionada', '$tipoServicio', '$coordenadas', '$ruta', '$costoOv')";
 
     if ($conn->query($sql) === TRUE) {
-        echo json_encode(['status' => 'success', 'message' => 'Check-out realizado correctamente.']);
         // Actualizar el estatus del préstamo a 'FINALIZADO'
         $updatePrestamo = "UPDATE prestamos SET estatus = 'FINALIZADO' WHERE id_prestamo = '$id_prestamo'";
         if (!empty($id_prestamo) && $finalizarPrestamo == 'Si') {
@@ -218,6 +237,11 @@ if($accion == 'CapturaCheckOut'){
                 //echo json_encode(['status' => 'error', 'message' => 'Error al actualizar el vehículo asignado: ' . $conn->error]);
                 //exit;
             }
+
+            // Calcular km recorrido de este check-out (origen GPS -> destino actividad/cliente)
+            calcularKmCheckinGlobal($conn, $coordenadas, $otRelacionada, $idUltimaActividad);
+
+        echo json_encode(['status' => 'success', 'message' => 'Check-out realizado correctamente.', 'id_actividad' => $idUltimaActividad]);
     } else {
         echo json_encode(['status' => 'error', 'message' => 'Error al realizar el check-out: ' . $conn->error]);
     }

--- a/acciones_qr.php
+++ b/acciones_qr.php
@@ -299,6 +299,7 @@ if ($accion === 'checkInQR') {
     $stmt->bind_param("iiisss", $id_vehiculo, $id_usuario_cookie, $km_actual, $ruta_foto, $coordenadas, $ot);
 
     if ($stmt->execute()) {
+        $id_actividad = $stmt->insert_id; // para ligar el km calculado a este check-in
         $conn->query("UPDATE inventario SET asignado = 'SI' WHERE id_vehiculo = " . $id_vehiculo);
         if ($km_actual > 0) {
             $stmtKm = $conn->prepare("INSERT INTO kilometrajes (id_vehiculo, km, fecha) VALUES (?, ?, NOW())");
@@ -306,7 +307,7 @@ if ($accion === 'checkInQR') {
             $stmtKm->execute();
             $stmtKm->close();
         }
-        echo json_encode(['success' => true]);
+        echo json_encode(['success' => true, 'id_actividad' => $id_actividad]);
     } else {
         echo json_encode(['error' => 'Error al registrar check-in.']);
     }
@@ -334,6 +335,7 @@ if ($accion === 'checkOutQR') {
     $stmt->bind_param("iiisss", $id_vehiculo, $id_usuario_cookie, $km_actual, $ruta_foto, $coordenadas, $ot);
 
     if ($stmt->execute()) {
+        $id_actividad = $stmt->insert_id; // para ligar el km calculado a este check-out
         $conn->query("UPDATE inventario SET asignado = 'NO' WHERE id_vehiculo = " . $id_vehiculo);
         $conn->query("UPDATE prestamos SET estatus = 'FINALIZADO', fecha_fin_prestamo = NOW() WHERE id_usuario = " . $id_usuario_cookie . " AND id_vehiculo = " . $id_vehiculo . " AND estatus = 'EN CURSO'");
         if ($km_actual > 0) {
@@ -342,7 +344,7 @@ if ($accion === 'checkOutQR') {
             $stmtKm->execute();
             $stmtKm->close();
         }
-        echo json_encode(['success' => true]);
+        echo json_encode(['success' => true, 'id_actividad' => $id_actividad]);
     } else {
         echo json_encode(['error' => 'Error al registrar check-out.']);
     }

--- a/calcular_ruta.php
+++ b/calcular_ruta.php
@@ -1,24 +1,33 @@
 <?php
-include __DIR__ . '/conn.php';
-header('Content-Type: application/json');
-mysqli_set_charset($conn, "utf8mb4");
-date_default_timezone_set('America/Mexico_City');
+/**
+ * Cálculo de km recorridos (origen check-in -> destino cliente/actividad).
+ *
+ * Doble uso:
+ *   - Endpoint AJAX: POST {ov_ot, lat, lng, [id_actividad]} desde el check-in QR.
+ *   - Librería incluible: define las funciones SIN ejecutar el endpoint, para
+ *     que el batch de reconciliación (al importar Actividades) reutilice la
+ *     misma lógica de cálculo. El bloque del endpoint solo corre cuando este
+ *     archivo es el script invocado directamente.
+ */
 
-$config    = @parse_ini_file(__DIR__ . '/token.ini');
-$INEGI_KEY = $config['INEGI_TOKEN'] ?? '';
-
-// Cuando la API INEGI falla, usamos haversine (distancia en linea recta) y
-// la multiplicamos por este factor para aproximar la ruta real por carretera.
+// Cuando la API INEGI falla, usamos haversine (línea recta) y la multiplicamos
+// por este factor para aproximar la ruta real por carretera.
 const HAVERSINE_FACTOR = 1.45;
 
-$ov_ot      = isset($_POST['ov_ot']) ? trim($_POST['ov_ot']) : '';
-$origen_lat = isset($_POST['lat'])   ? floatval($_POST['lat']) : null;
-$origen_lng = isset($_POST['lng'])   ? floatval($_POST['lng']) : null;
-$id_usuario = isset($_COOKIE['id_usuarioL']) ? intval($_COOKIE['id_usuarioL']) : null;
+// INEGI Sakbé tiene una red vial por escala (cada escala es un grafo distinto).
+// Ningún escala cubre todos los puntos: los urbanos resuelven en escalas finas,
+// los remotos/industriales solo en las gruesas. Se prueba de fino a grueso y se
+// usa el primer escala donde TANTO origen como destino resuelven (ruta más
+// detallada posible). Origen y destino deben salir del MISMO escala para rutear.
+const ESCALAS_INEGI = [20000, 50000, 250000, 1000000];
 
-if ($ov_ot === '' || $origen_lat === null || $origen_lng === null) {
-    echo json_encode(['status' => 'error', 'message' => 'Parámetros incompletos']);
-    exit;
+function tokenInegi(): string {
+    static $key = null;
+    if ($key === null) {
+        $cfg = @parse_ini_file(__DIR__ . '/token.ini');
+        $key = $cfg['INEGI_TOKEN'] ?? '';
+    }
+    return $key;
 }
 
 function resolverCliente(mysqli $conn, string $ov_ot): ?int {
@@ -37,6 +46,54 @@ function resolverCliente(mysqli $conn, string $ov_ot): ?int {
     return !empty($r['id_cliente']) ? intval($r['id_cliente']) : null;
 }
 
+/**
+ * Fallback OTROS: actividad del usuario en la tabla `otros` (poblada al importar
+ * el CSV de Actividades) cuya fecha coincide con el día de referencia del
+ * check-in. Excluye actividades ya consumidas por otro check-in (su order_code
+ * ya quedó registrado en actividad_vehiculo).
+ *
+ * `marca` es el identificador que se graba en actividad_vehiculo.order_code para
+ * marcar la actividad como consumida: el order_code del CSV, o 'OTROS-{id}' si
+ * la fila no trajo order_code (siempre no-nulo, así nunca se procesa dos veces).
+ *
+ * @param string $fechaRef fecha/hora del check-in ('Y-m-d H:i:s'); se compara por día.
+ * @return array{id_cliente:int,actividad:string,lat:?float,lng:?float,marca:string}|null
+ */
+function resolverClienteOtros(mysqli $conn, int $id_usuario, string $fechaRef): ?array {
+    try {
+        // COLLATE explícito: otros.order_code y actividad_vehiculo.order_code
+        // tienen collations distintas (tabla nueva vs vieja); sin esto el NOT IN
+        // lanza "Illegal mix of collations".
+        $sql = "SELECT id_cliente, actividad, latitude, longitude,
+                       COALESCE(order_code, CONCAT('OTROS-', id)) AS marca
+                FROM otros
+                WHERE id_usuario = ?
+                  AND fecha IS NOT NULL
+                  AND DATE(fecha) = DATE(?)
+                  AND COALESCE(order_code, CONCAT('OTROS-', id)) COLLATE utf8mb4_general_ci NOT IN (
+                        SELECT order_code COLLATE utf8mb4_general_ci
+                        FROM actividad_vehiculo WHERE order_code IS NOT NULL)
+                ORDER BY fecha DESC, id DESC
+                LIMIT 1";
+        $stmt = $conn->prepare($sql);
+        if (!$stmt) return null; // la tabla aún no existe (sin importación previa)
+        $stmt->bind_param("is", $id_usuario, $fechaRef);
+        $stmt->execute();
+        $r = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        if (!$r || empty($r['id_cliente'])) return null;
+        return [
+            'id_cliente' => intval($r['id_cliente']),
+            'actividad'  => (string) $r['actividad'],
+            'lat'        => $r['latitude']  !== null ? floatval($r['latitude'])  : null,
+            'lng'        => $r['longitude'] !== null ? floatval($r['longitude']) : null,
+            'marca'      => (string) $r['marca'],
+        ];
+    } catch (Throwable $e) {
+        return null;
+    }
+}
+
 function obtenerCoordsCliente(mysqli $conn, int $id_cliente): ?array {
     $stmt = $conn->prepare("SELECT lat, lng FROM clientes WHERE IDCLTE = ? LIMIT 1");
     $stmt->bind_param("i", $id_cliente);
@@ -47,12 +104,64 @@ function obtenerCoordsCliente(mysqli $conn, int $id_cliente): ?array {
     return ['lat' => floatval($r['lat']), 'lng' => floatval($r['lng'])];
 }
 
-function buscarLineaInegi(float $lng, float $lat, string $key): ?array {
+/** Sedes MESS (cacheadas). Cada una con su radio en km (default 3). */
+function obtenerSedes(mysqli $conn): array {
+    static $sedes = null;
+    if ($sedes !== null) return $sedes;
+    $sedes = [];
+    $r = @$conn->query("SELECT lat, lng, radio_km FROM sedes");
+    if ($r) {
+        while ($s = $r->fetch_assoc()) {
+            $sedes[] = [
+                'lat'   => floatval($s['lat']),
+                'lng'   => floatval($s['lng']),
+                'radio' => floatval($s['radio_km']) > 0 ? floatval($s['radio_km']) : 3.0,
+            ];
+        }
+    }
+    return $sedes;
+}
+
+/** Distancia en línea recta (sin factor), para el chequeo de radio de sede. */
+function haversineRectaKm(float $lat1, float $lng1, float $lat2, float $lng2): float {
+    $R = 6371.0;
+    $dLat = deg2rad($lat2 - $lat1);
+    $dLng = deg2rad($lng2 - $lng1);
+    $a = sin($dLat / 2) ** 2 + cos(deg2rad($lat1)) * cos(deg2rad($lat2)) * sin($dLng / 2) ** 2;
+    return 2 * $R * asin(sqrt($a));
+}
+
+/** True si (lat,lng) cae dentro del radio de alguna sede MESS. */
+function dentroDeSede(mysqli $conn, float $lat, float $lng): bool {
+    foreach (obtenerSedes($conn) as $s) {
+        if (haversineRectaKm($lat, $lng, $s['lat'], $s['lng']) <= $s['radio']) return true;
+    }
+    return false;
+}
+
+/**
+ * Destino del km para una actividad OTROS: las coordenadas de la propia
+ * actividad, salvo que sean inválidas (0,0) o caigan dentro del radio de una
+ * sede MESS, en cuyo caso se usan las coordenadas registradas del cliente.
+ * @return array{lat:float,lng:float,fuente:string}|null
+ */
+function resolverDestino(mysqli $conn, ?float $actLat, ?float $actLng, int $id_cliente): ?array {
+    if ($actLat !== null && $actLng !== null && !($actLat == 0.0 && $actLng == 0.0)) {
+        if (!dentroDeSede($conn, $actLat, $actLng)) {
+            return ['lat' => $actLat, 'lng' => $actLng, 'fuente' => 'actividad'];
+        }
+    }
+    $c = obtenerCoordsCliente($conn, $id_cliente);
+    if ($c !== null) $c['fuente'] = 'cliente';
+    return $c;
+}
+
+function buscarLineaInegi(float $lng, float $lat, string $key, int $escala = 250000): ?array {
     $ch = curl_init('https://gaia.inegi.org.mx/sakbe_v3.1/buscalinea');
     curl_setopt_array($ch, [
         CURLOPT_POST           => true,
         CURLOPT_POSTFIELDS     => http_build_query([
-            'x' => $lng, 'y' => $lat, 'escala' => 250000,
+            'x' => $lng, 'y' => $lat, 'escala' => $escala,
             'type' => 'json', 'proj' => 'GRS80', 'key' => $key,
         ]),
         CURLOPT_RETURNTRANSFER => true,
@@ -93,83 +202,282 @@ function calcularRutaInegi(array $origen, array $destino, string $key): ?array {
 }
 
 function haversineKm(float $lat1, float $lng1, float $lat2, float $lng2): float {
-    $R = 6371.0;
-    $dLat = deg2rad($lat2 - $lat1);
-    $dLng = deg2rad($lng2 - $lng1);
-    $a = sin($dLat / 2) ** 2 + cos(deg2rad($lat1)) * cos(deg2rad($lat2)) * sin($dLng / 2) ** 2;
-    $kmRecta = 2 * $R * asin(sqrt($a));
-    return round($kmRecta * HAVERSINE_FACTOR, 3);
+    return round(haversineRectaKm($lat1, $lng1, $lat2, $lng2) * HAVERSINE_FACTOR, 3);
 }
 
-function registrarKm(mysqli $conn, $ov_ot, $id_cliente, $oLat, $oLng, $dLat, $dLng, $km, $min, $metodo, $estatus, $error, $id_usuario): void {
+/**
+ * Ruta INEGI probando escalas de fina a gruesa hasta que origen y destino
+ * resuelvan en el MISMO escala y /libre devuelva distancia. Devuelve
+ * ['km','tiempo','escala'] o null si ningún escala funciona.
+ */
+function rutaInegiCascada(float $oLat, float $oLng, float $dLat, float $dLng, string $key): ?array {
+    foreach (ESCALAS_INEGI as $e) {
+        $lo = buscarLineaInegi($oLng, $oLat, $key, $e);
+        if (!isset($lo['data']['id_routing_net'])) continue;
+        $ld = buscarLineaInegi($dLng, $dLat, $key, $e);
+        if (!isset($ld['data']['id_routing_net'])) continue;
+        $ruta = calcularRutaInegi($lo['data'], $ld['data'], $key);
+        if (isset($ruta['data']['long_km'])) {
+            return [
+                'km'     => floatval($ruta['data']['long_km']),
+                'tiempo' => isset($ruta['data']['tiempo_min']) ? floatval($ruta['data']['tiempo_min']) : null,
+                'escala' => $e,
+            ];
+        }
+    }
+    return null;
+}
+
+function registrarKm(mysqli $conn, $ov_ot, $id_cliente, $oLat, $oLng, $dLat, $dLng, $km, $min, $metodo, $estatus, $error, $id_usuario, int $id_actividad = 0): void {
+    // Si este check-in ya dejó un placeholder 'sin_actividad', se RELLENA esa misma
+    // fila (no se duplica) — es lo que pasa cuando el batch encuentra la actividad.
+    if ($id_actividad > 0) {
+        $q = $conn->prepare("SELECT id FROM km_calculados WHERE id_actividad = ? AND estatus = 'sin_actividad' ORDER BY id DESC LIMIT 1");
+        $q->bind_param("i", $id_actividad);
+        $q->execute();
+        $row = $q->get_result()->fetch_assoc();
+        $q->close();
+        if ($row) {
+            $u = $conn->prepare("UPDATE km_calculados
+                SET ov_ot = ?, id_cliente = ?, destino_lat = ?, destino_lng = ?, long_km = ?, tiempo_min = ?, metodo = ?, estatus = ?, error_msg = ?
+                WHERE id = ?");
+            $u->bind_param("siddddsssi", $ov_ot, $id_cliente, $dLat, $dLng, $km, $min, $metodo, $estatus, $error, $row['id']);
+            $u->execute();
+            $u->close();
+            return;
+        }
+    }
+
     $stmt = $conn->prepare("INSERT INTO km_calculados
-        (ov_ot, id_cliente, origen_lat, origen_lng, destino_lat, destino_lng, long_km, tiempo_min, metodo, estatus, error_msg, id_usuario)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+        (ov_ot, id_cliente, origen_lat, origen_lng, destino_lat, destino_lng, long_km, tiempo_min, metodo, estatus, error_msg, id_usuario, id_actividad)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
     $stmt->bind_param(
-        "siddddddsssi",
-        $ov_ot, $id_cliente, $oLat, $oLng, $dLat, $dLng, $km, $min, $metodo, $estatus, $error, $id_usuario
+        "siddddddsssii",
+        $ov_ot, $id_cliente, $oLat, $oLng, $dLat, $dLng, $km, $min, $metodo, $estatus, $error, $id_usuario, $id_actividad
     );
     $stmt->execute();
     $stmt->close();
 }
 
-$id_cliente = resolverCliente($conn, $ov_ot);
-if ($id_cliente === null) {
-    echo json_encode(['status' => 'error', 'message' => "OV/OT '$ov_ot' no encontrada"]);
-    exit;
-}
+/**
+ * Calcula la ruta INEGI (fallback haversine) entre origen y destino y registra
+ * la fila en km_calculados. Reutilizable por el endpoint y por el batch.
+ * @return array{km:?float,tiempo_min:?float,metodo:string,estatus:string,aviso:?string}
+ */
+function calcularYRegistrar(mysqli $conn, $ov_ot, int $id_cliente, float $oLat, float $oLng, array $destino, ?int $id_usuario, int $id_actividad = 0): array {
+    $key   = tokenInegi();
+    $dLat  = $destino['lat'];
+    $dLng  = $destino['lng'];
+    $metodo = 'inegi'; $estatus = 'ok'; $error = null; $km = null; $tiempo = null;
 
-$destino = obtenerCoordsCliente($conn, $id_cliente);
-if ($destino === null) {
-    registrarKm($conn, $ov_ot, $id_cliente, $origen_lat, $origen_lng,
-        null, null, null, null, 'haversine', 'sin_destino',
-        'Cliente sin lat/lng en BD', $id_usuario);
-    echo json_encode([
-        'status'  => 'error',
-        'message' => 'El cliente no tiene coordenadas registradas',
-        'id_cliente' => $id_cliente,
-    ]);
-    exit;
-}
+    $ruta = $key ? rutaInegiCascada($oLat, $oLng, $dLat, $dLng, $key) : null;
 
-$destino_lat = $destino['lat'];
-$destino_lng = $destino['lng'];
-
-$metodo    = 'inegi';
-$estatus   = 'ok';
-$error_msg = null;
-$km        = null;
-$tiempo    = null;
-
-$linea_o = $INEGI_KEY ? buscarLineaInegi($origen_lng, $origen_lat, $INEGI_KEY) : null;
-$linea_d = $INEGI_KEY ? buscarLineaInegi($destino_lng, $destino_lat, $INEGI_KEY) : null;
-
-if (isset($linea_o['data']['id_routing_net'], $linea_d['data']['id_routing_net'])) {
-    $ruta = calcularRutaInegi($linea_o['data'], $linea_d['data'], $INEGI_KEY);
-    if (isset($ruta['data']['long_km'])) {
-        $km     = floatval($ruta['data']['long_km']);
-        $tiempo = isset($ruta['data']['tiempo_min']) ? floatval($ruta['data']['tiempo_min']) : null;
+    if ($ruta !== null) {
+        $km     = $ruta['km'];
+        $tiempo = $ruta['tiempo'];
     } else {
-        $metodo    = 'haversine';
-        $estatus   = 'error_api';
-        $error_msg = 'INEGI /libre sin long_km';
-        $km        = haversineKm($origen_lat, $origen_lng, $destino_lat, $destino_lng);
+        $metodo = 'haversine'; $estatus = 'error_api';
+        $error  = $key === '' ? 'Token INEGI ausente' : 'INEGI sin ruta en ninguna escala';
+        $km     = haversineKm($oLat, $oLng, $dLat, $dLng);
     }
-} else {
-    $metodo    = 'haversine';
-    $estatus   = 'error_api';
-    $error_msg = $INEGI_KEY === '' ? 'Token INEGI ausente' : 'INEGI /buscalinea sin id_routing_net';
-    $km        = haversineKm($origen_lat, $origen_lng, $destino_lat, $destino_lng);
+
+    registrarKm($conn, $ov_ot, $id_cliente, $oLat, $oLng, $dLat, $dLng, $km, $tiempo, $metodo, $estatus, $error, $id_usuario, $id_actividad);
+    return ['km' => $km, 'tiempo_min' => $tiempo, 'metodo' => $metodo, 'estatus' => $estatus, 'aviso' => $error];
 }
 
-registrarKm($conn, $ov_ot, $id_cliente, $origen_lat, $origen_lng,
-    $destino_lat, $destino_lng, $km, $tiempo, $metodo, $estatus, $error_msg, $id_usuario);
+/**
+ * Reconciliación batch (se llama al importar el CSV de Actividades).
+ *
+ * Busca check-ins "incompletos" — registros de actividad_vehiculo tipo INICIO,
+ * con GPS, cuyo km aún no se calculó (order_code IS NULL) — y los empareja con
+ * la actividad OTROS del MISMO DÍA del usuario que acaba de llegar en el CSV.
+ * Cubre el caso en que el chofer sube su registro de actividad después del
+ * check-in. Los check-ins de OV/OT se ignoran (ya se calculan en vivo).
+ *
+ * @return array contadores: revisados, calculados, sin_actividad, sin_destino, ovot
+ */
+function reconciliarKmPendientes(mysqli $conn, int $diasAtras = 30): array {
+    $res = ['revisados' => 0, 'calculados' => 0, 'sin_actividad' => 0, 'sin_destino' => 0, 'ovot' => 0];
 
-echo json_encode([
-    'status'     => 'success',
-    'km'         => $km,
-    'tiempo_min' => $tiempo,
-    'metodo'     => $metodo,
-    'aviso'      => $error_msg,
-    'id_cliente' => $id_cliente,
-]);
+    $stmt = $conn->prepare("SELECT id_actividad, id_usuario, coordenadas, ot, fecha_actividad
+        FROM actividad_vehiculo
+        WHERE order_code IS NULL
+          AND tipo_actividad = 'INICIO'
+          AND coordenadas IS NOT NULL AND coordenadas <> ''
+          AND fecha_actividad >= (NOW() - INTERVAL ? DAY)
+        ORDER BY id_actividad");
+    if (!$stmt) return $res;
+    $stmt->bind_param("i", $diasAtras);
+    $stmt->execute();
+    $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
+
+    foreach ($rows as $row) {
+        $res['revisados']++;
+
+        $partes = explode(',', (string) $row['coordenadas']);
+        if (count($partes) < 2) continue;
+        $oLat = floatval(trim($partes[0]));
+        $oLng = floatval(trim($partes[1]));
+        if ($oLat == 0.0 && $oLng == 0.0) continue;
+
+        // Si el ot resuelve como OV/OT, ya se manejó en vivo: saltar.
+        $ot = trim((string) $row['ot']);
+        if ($ot !== '' && resolverCliente($conn, $ot) !== null) { $res['ovot']++; continue; }
+
+        $id_usuario = intval($row['id_usuario']);
+        $otros = resolverClienteOtros($conn, $id_usuario, (string) $row['fecha_actividad']);
+        if ($otros === null) { $res['sin_actividad']++; continue; }
+
+        $destino = resolverDestino($conn, $otros['lat'], $otros['lng'], $otros['id_cliente']);
+        if ($destino === null) { $res['sin_destino']++; continue; }
+
+        calcularYRegistrar($conn, $otros['actividad'], $otros['id_cliente'], $oLat, $oLng, $destino, $id_usuario, (int) $row['id_actividad']);
+
+        // Marca el check-in: tipo de actividad, order_code de SCOT y limpia `ot`.
+        marcarCheckin($conn, (int) $row['id_actividad'], [
+            'detalle'    => $otros['actividad'],
+            'order_code' => $otros['marca'],
+            'limpiar_ot' => true,
+        ]);
+        $res['calculados']++;
+    }
+    return $res;
+}
+
+/**
+ * Orquesta el cálculo de km de UN check-in: resuelve cliente (OV/OT u OTROS del
+ * día), resuelve destino (coords de actividad validadas vs sedes, o del cliente),
+ * registra km_calculados y marca order_code en el check-in. Reutilizable por el
+ * endpoint QR y por el check-in del modal global (acciones_kilometraje.php).
+ *
+ * @param string $fechaRef fecha/hora del check-in ('Y-m-d H:i:s') para el match OTROS.
+ * @return array resultado con 'status' => 'success'|'error'.
+ */
+/** Tipos de actividad SCOT (no son OV/OT). Si llegan en `ot`, NO son códigos
+ *  válidos: se limpian de `ot` y el tipo va a detalle_tipo_uso. */
+const TIPOS_ACTIVIDAD = ['VISITA', 'APPVISITA', 'OTRO'];
+
+function esTipoActividad(string $v): bool {
+    return in_array(strtoupper(trim($v)), TIPOS_ACTIVIDAD, true);
+}
+
+/**
+ * Marca el check-in (actividad_vehiculo) tras resolver su km:
+ *  - 'order_code': el de la actividad OTROS (link a SCOT + "ya calculado").
+ *  - 'limpiar_ot': deja `ot` vacío cuando NO es OV/OT (ot SOLO guarda OV/OT).
+ *  - 'detalle'   : tipo de actividad (VISITA/APPVISITA/OTRO); va a detalle_tipo_uso
+ *    SOLO si está vacío (no pisa el tipoServicio real del modal global).
+ */
+function marcarCheckin(mysqli $conn, int $idActividad, array $c): void {
+    if ($idActividad <= 0) return;
+
+    if (!empty($c['order_code'])) {
+        $s = $conn->prepare("UPDATE actividad_vehiculo SET order_code = ? WHERE id_actividad = ?");
+        $s->bind_param("si", $c['order_code'], $idActividad);
+        $s->execute(); $s->close();
+    }
+    if (!empty($c['limpiar_ot'])) {
+        $s = $conn->prepare("UPDATE actividad_vehiculo SET ot = '' WHERE id_actividad = ?");
+        $s->bind_param("i", $idActividad);
+        $s->execute(); $s->close();
+    }
+    if (!empty($c['detalle'])) {
+        $s = $conn->prepare("UPDATE actividad_vehiculo SET detalle_tipo_uso = ?
+            WHERE id_actividad = ? AND (detalle_tipo_uso IS NULL OR detalle_tipo_uso = '')");
+        $s->bind_param("si", $c['detalle'], $idActividad);
+        $s->execute(); $s->close();
+    }
+}
+
+function procesarKmCheckin(mysqli $conn, string $ov_ot, ?float $oLat, ?float $oLng, ?int $id_usuario, int $id_actividad, string $fechaRef): array {
+    if ($oLat === null || $oLng === null) {
+        return ['status' => 'error', 'message' => 'Sin coordenadas de origen'];
+    }
+
+    // Si `ot` trae un TIPO de actividad (VISITA/APPVISITA/OTRO), no es un OV/OT:
+    // lo capturamos para detalle_tipo_uso y lo limpiamos de `ot`.
+    $tipoActividad = esTipoActividad($ov_ot) ? strtoupper(trim($ov_ot)) : null;
+    if ($tipoActividad !== null) $ov_ot = '';
+
+    $id_cliente = $ov_ot !== '' ? resolverCliente($conn, $ov_ot) : null;
+    $esOvOt     = $id_cliente !== null;      // el ot capturado SÍ es un OV/OT válido
+    $otros      = null;
+
+    // Fallback OTROS: si no es OV/OT, tomar la actividad del usuario del día.
+    if ($id_cliente === null && $id_usuario) {
+        $otros = resolverClienteOtros($conn, $id_usuario, $fechaRef);
+        if ($otros !== null) $id_cliente = $otros['id_cliente'];
+    }
+
+    // Sin OV/OT y sin actividad OTROS: no hay destino. Igual:
+    //  - guardamos el TIPO de actividad en detalle_tipo_uso y limpiamos `ot`;
+    //  - dejamos un registro/indicador en km_calculados con estatus 'sin_actividad'
+    //    (origen sí, destino/km no) para que ningún check-in quede sin huella.
+    if ($id_cliente === null) {
+        marcarCheckin($conn, $id_actividad, ['detalle' => $tipoActividad, 'limpiar_ot' => $tipoActividad !== null]);
+        registrarKm($conn, (string) ($tipoActividad ?? ''), null, $oLat, $oLng,
+            null, null, null, null, 'haversine', 'sin_actividad',
+            'Sin OV/OT ni actividad OTROS del día', $id_usuario, $id_actividad);
+        return ['status' => 'error', 'message' => $ov_ot !== '' ? "OV/OT '$ov_ot' no encontrada" : 'Sin actividad OTROS para el usuario'];
+    }
+
+    // En km_calculados.ov_ot va el código OV/OT, o el tipo de actividad si es OTROS.
+    $ovOtKm = $esOvOt ? $ov_ot : (string) $otros['actividad'];
+
+    // Destino: OTROS usa coords de la actividad (validadas vs sedes) o del
+    // cliente; OV/OT usa siempre las del cliente.
+    $destino = $otros !== null
+        ? resolverDestino($conn, $otros['lat'], $otros['lng'], $id_cliente)
+        : obtenerCoordsCliente($conn, $id_cliente);
+
+    if ($destino === null) {
+        registrarKm($conn, $ovOtKm, $id_cliente, $oLat, $oLng,
+            null, null, null, null, 'haversine', 'sin_destino',
+            'Cliente sin lat/lng en BD', $id_usuario, $id_actividad);
+        if ($otros !== null) {
+            marcarCheckin($conn, $id_actividad, ['detalle' => $otros['actividad'], 'order_code' => $otros['marca'], 'limpiar_ot' => true]);
+        }
+        return ['status' => 'error', 'message' => 'El cliente no tiene coordenadas registradas', 'id_cliente' => $id_cliente];
+    }
+
+    $r = calcularYRegistrar($conn, $ovOtKm, $id_cliente, $oLat, $oLng, $destino, $id_usuario, $id_actividad);
+
+    // OTROS: tipo de actividad -> detalle_tipo_uso, order_code de SCOT, y se limpia
+    // `ot` (solo guarda OV/OT). OV/OT: se respeta el `ot` capturado.
+    if ($otros !== null) {
+        marcarCheckin($conn, $id_actividad, ['detalle' => $otros['actividad'], 'order_code' => $otros['marca'], 'limpiar_ot' => true]);
+    }
+
+    return [
+        'status'     => 'success',
+        'km'         => $r['km'],
+        'tiempo_min' => $r['tiempo_min'],
+        'metodo'     => $r['metodo'],
+        'aviso'      => $r['aviso'],
+        'id_cliente' => $id_cliente,
+    ];
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint AJAX (solo cuando se invoca este archivo directamente)
+// ---------------------------------------------------------------------------
+if (realpath($_SERVER['SCRIPT_FILENAME'] ?? '') === realpath(__FILE__)) {
+    include __DIR__ . '/conn.php';
+    header('Content-Type: application/json');
+    mysqli_set_charset($conn, "utf8mb4");
+    date_default_timezone_set('America/Mexico_City');
+
+    $ov_ot        = isset($_POST['ov_ot']) ? trim($_POST['ov_ot']) : '';
+    $origen_lat   = isset($_POST['lat'])   ? floatval($_POST['lat']) : null;
+    $origen_lng   = isset($_POST['lng'])   ? floatval($_POST['lng']) : null;
+    $id_actividad = isset($_POST['id_actividad']) ? intval($_POST['id_actividad']) : 0;
+    $id_usuario   = intval($_COOKIE['id_usuarioL'] ?? $_COOKIE['id_usuario'] ?? 0) ?: null;
+
+    if ($origen_lat === null || $origen_lng === null) {
+        echo json_encode(['status' => 'error', 'message' => 'Parámetros incompletos']);
+        exit;
+    }
+
+    echo json_encode(procesarKmCheckin($conn, $ov_ot, $origen_lat, $origen_lng, $id_usuario, $id_actividad, date('Y-m-d H:i:s')));
+}

--- a/encabezado.php
+++ b/encabezado.php
@@ -429,6 +429,34 @@
         }
     }
     
+    // Pide la ubicación de forma OBLIGATORIA al registrar un check-in/out.
+    // Resuelve con {lat, lng} o rechaza si no se pudo obtener.
+    function obtenerUbicacionObligatoria() {
+        return new Promise(function (resolve, reject) {
+            if (!navigator.geolocation) { reject(); return; }
+            navigator.geolocation.getCurrentPosition(
+                function (pos) {
+                    resolve({
+                        lat: parseFloat(pos.coords.latitude.toFixed(6)),
+                        lng: parseFloat(pos.coords.longitude.toFixed(6))
+                    });
+                },
+                function () { reject(); },
+                { enableHighAccuracy: true, timeout: 15000, maximumAge: 0 }
+            );
+        });
+    }
+
+    // Aviso reutilizable cuando la ubicación es obligatoria y no se obtuvo.
+    function avisoUbicacionObligatoria() {
+        Swal.fire({
+            icon: 'error',
+            title: 'Ubicación obligatoria',
+            text: 'No pudimos obtener tu ubicación. Habilita el GPS y el permiso de ubicación del navegador e inténtalo de nuevo.',
+            confirmButtonText: 'Entendido'
+        });
+    }
+
     // Función para cargar y mostrar actividades pendientes en el modal
     // Sobrescribe la función para mostrar actividades en tabla
     function mostrarActividadesPendientes() {
@@ -515,6 +543,11 @@
             $('#PidPrestamo').val('');
         }
         
+        // La ubicación es OBLIGATORIA: sin coords de origen no se registra el check-in.
+        obtenerUbicacionObligatoria().then(function (geo) {
+        coordenadas = geo.lat + ', ' + geo.lng;
+        $('#coordenadasCheck').val(coordenadas);
+
         var formData = new FormData();
         formData.append('id_prestamo', $('#PidPrestamo').val()); // Asignar un ID de préstamo por defecto
         formData.append('accion', 'CapturaCheckIn');
@@ -579,6 +612,7 @@
                 $('#capturaKmModal').modal('show');
             }
         });
+        }).catch(function () { avisoUbicacionObligatoria(); });
     }
 
     // Función para capturar el check-out
@@ -602,6 +636,11 @@
         $('#msgKm').text('Por favor, complete todos los campos obligatorios.');
         return;
         }
+
+        // La ubicación es OBLIGATORIA: sin coords de origen no se registra el check-out.
+        obtenerUbicacionObligatoria().then(function (geo) {
+        coordenadas = geo.lat + ', ' + geo.lng;
+        $('#coordenadasCheck').val(coordenadas);
 
         var formData = new FormData();
         formData.append('accion', 'CapturaCheckOut');
@@ -654,9 +693,9 @@
             $('#msgKm').text('Error al guardar el kilometraje.');
         }
         });
-        
+        }).catch(function () { avisoUbicacionObligatoria(); });
     }
-    
+
     // Función para agregar otro input de archivo, hasta un máximo de 4
     function agregarInputImagen() {
         // Contenedor donde están los inputs de imagen

--- a/importar_reportes.php
+++ b/importar_reportes.php
@@ -68,14 +68,14 @@ if (empty($_COOKIE['noEmpleado'])) {
                             </div>
                             <div class="card-body">
                                 <form id="formImportar" enctype="multipart/form-data">
-                                    <p class="text-muted mb-4"> El sistema importa OV/OT y geocodifica clientes nuevos automaticamente.</p>
+                                    <p class="text-muted mb-4"> El sistema importa OV/OT, geocodifica clientes nuevos y, si subes el archivo de Actividades, las carga para calcular los KM al hacer check-in por QR.</p>
                                     <div class="row g-3">
                                         <div class="col-md-4">
                                             <label class="form-label fw-semibold small mb-1">Ventas</label>
                                             <label class="file-drop" id="dropVentas" for="csvVentas">
                                                 <i class="fas fa-file-csv fa-2x text-muted mb-2 d-block"></i>
                                                 <span class="file-name" id="nameVentas">VENTAS_*.csv</span>
-                                                <input type="file" id="csvVentas" name="ventas" accept=".csv" required>
+                                                <input type="file" id="csvVentas" name="ventas" accept=".csv">
                                             </label>
                                         </div>
 
@@ -84,7 +84,7 @@ if (empty($_COOKIE['noEmpleado'])) {
                                             <label class="file-drop" id="dropTiempoSitio" for="csvTiempoSitio">
                                                 <i class="fas fa-file-csv fa-2x text-muted mb-2 d-block"></i>
                                                 <span class="file-name" id="nameTiempoSitio">DETALLE-TIEMPO-SITIO_*.csv</span>
-                                                <input type="file" id="csvTiempoSitio" name="tiempo_sitio" accept=".csv" required>
+                                                <input type="file" id="csvTiempoSitio" name="tiempo_sitio" accept=".csv">
                                             </label>
                                         </div>
 
@@ -93,7 +93,16 @@ if (empty($_COOKIE['noEmpleado'])) {
                                             <label class="file-drop" id="dropSinTiempo" for="csvSinTiempo">
                                                 <i class="fas fa-file-csv fa-2x text-muted mb-2 d-block"></i>
                                                 <span class="file-name" id="nameSinTiempo">DETALLE-SIN-TIEMPO_*.csv</span>
-                                                <input type="file" id="csvSinTiempo" name="sin_tiempo" accept=".csv" required>
+                                                <input type="file" id="csvSinTiempo" name="sin_tiempo" accept=".csv">
+                                            </label>
+                                        </div>
+
+                                        <div class="col-md-4">
+                                            <label class="form-label fw-semibold small mb-1">Actividades</label>
+                                            <label class="file-drop" id="dropOtros" for="csvOtros">
+                                                <i class="fas fa-file-csv fa-2x text-muted mb-2 d-block"></i>
+                                                <span class="file-name" id="nameOtros">FactActividades_*.csv</span>
+                                                <input type="file" id="csvOtros" name="otros" accept=".csv">
                                             </label>
                                         </div>
                                     </div>
@@ -180,7 +189,8 @@ if (empty($_COOKIE['noEmpleado'])) {
             var mapa = {
                 csvVentas: 'nameVentas',
                 csvTiempoSitio: 'nameTiempoSitio',
-                csvSinTiempo: 'nameSinTiempo'
+                csvSinTiempo: 'nameSinTiempo',
+                csvOtros: 'nameOtros'
             };
             Object.keys(mapa).forEach(function (inputId) {
                 document.getElementById(inputId).addEventListener('change', function () {
@@ -200,17 +210,19 @@ if (empty($_COOKIE['noEmpleado'])) {
             var ventas       = $('#csvVentas')[0].files[0];
             var tiempoSitio  = $('#csvTiempoSitio')[0].files[0];
             var sinTiempo    = $('#csvSinTiempo')[0].files[0];
+            var otros        = $('#csvOtros')[0].files[0];
 
-            if (!ventas || !tiempoSitio || !sinTiempo) {
-                Swal.fire({ icon: 'warning', title: 'Faltan archivos', text: 'Sube los 3 archivos CSV.', confirmButtonText: 'Aceptar' });
+            if (!ventas && !tiempoSitio && !sinTiempo && !otros) {
+                Swal.fire({ icon: 'warning', title: 'Falta archivo', text: 'Sube al menos un archivo CSV.', confirmButtonText: 'Aceptar' });
                 return;
             }
 
             var fd = new FormData();
             fd.append('accion', 'ejecutar');
-            fd.append('ventas', ventas);
-            fd.append('tiempo_sitio', tiempoSitio);
-            fd.append('sin_tiempo', sinTiempo);
+            if (ventas) fd.append('ventas', ventas);
+            if (tiempoSitio) fd.append('tiempo_sitio', tiempoSitio);
+            if (sinTiempo) fd.append('sin_tiempo', sinTiempo);
+            if (otros) fd.append('otros', otros);
             fd.append('geocodificar', $('#chkGeocodificar').is(':checked') ? '1' : '0');
 
             $('#btnImportar').prop('disabled', true).html('<span class="spinner-border spinner-border-sm me-1"></span> Procesando...');
@@ -260,6 +272,11 @@ if (empty($_COOKIE['noEmpleado'])) {
                 html += '<tr><td class="text-muted">Clientes geocodificados (exactos)</td><td class="fw-semibold">' + (r.geo.ok || 0) + '</td></tr>';
                 html += '<tr><td class="text-muted">Clientes geocodificados (centroide CP)</td><td class="fw-semibold">' + (r.geo.cp || 0) + '</td></tr>';
                 html += '<tr><td class="text-muted">Clientes fallidos</td><td class="fw-semibold">' + (r.geo.err || 0) + '</td></tr>';
+            }
+            if (r.otros) {
+                html += '<tr><td class="text-muted">Actividades importadas</td><td class="fw-semibold">' + (r.otros.ok || 0) + '</td></tr>';
+                html += '<tr><td class="text-muted">Actividades ignoradas (correo/llamada)</td><td class="fw-semibold">' + (r.otros.ignoradas || 0) + '</td></tr>';
+                html += '<tr><td class="text-muted">Actividades duplicadas (omitidas)</td><td class="fw-semibold">' + (r.otros.dup || 0) + '</td></tr>';
             }
             html += '<tr><td class="text-muted">Tiempo total</td><td class="fw-semibold">' + (r.duracion || '?') + ' seg</td></tr>';
             html += '</tbody></table>';

--- a/qr_vehiculo.php
+++ b/qr_vehiculo.php
@@ -750,9 +750,11 @@ if (empty($_COOKIE['noEmpleado'])) {
                             }, { once: true });
                             bootstrap.Modal.getInstance(modalEl).hide();
 
-                            // Si el usuario capturó OT/OV y tenemos GPS, registramos km en paralelo
-                            if (otOv && latNum != null && lngNum != null) {
-                                calcularRutaAsync(otOv, latNum, lngNum);
+                            // Con GPS registramos km en paralelo. Si hay OV/OT se usa ese cliente;
+                            // si no, calcular_ruta.php cae a la actividad del usuario (tabla otros).
+                            // id_actividad liga el km a este check-in (marca order_code).
+                            if (latNum != null && lngNum != null) {
+                                calcularRutaAsync(otOv, latNum, lngNum, resp.id_actividad);
                             }
                         } else {
                             Swal.fire({ icon: 'error', title: 'Error', text: resp.error || 'No se pudo registrar.', confirmButtonText: 'Aceptar' });
@@ -767,22 +769,30 @@ if (empty($_COOKIE['noEmpleado'])) {
                 });
             }
 
-            if (navigator.geolocation) {
-                navigator.geolocation.getCurrentPosition(
-                    function (pos) { enviar(pos.coords.latitude, pos.coords.longitude); },
-                    function () { enviar(null, null); },
-                    { timeout: 5000, maximumAge: 60000 }
-                );
-            } else {
-                enviar(null, null);
+            // La ubicación es OBLIGATORIA: sin coords de origen no se registra el check-in.
+            function gpsFallo() {
+                Swal.fire({
+                    icon: 'error',
+                    title: 'Activa tu ubicación',
+                    text: 'No pudimos obtener tu ubicación, que es obligatoria para registrar el check-in. Habilita el GPS y el permiso de ubicación del navegador e inténtalo de nuevo.',
+                    confirmButtonText: 'Reintentar'
+                });
+                $('#btnGuardarCheckinKM').prop('disabled', false).text(esCheckout ? 'Registrar Salida' : 'Registrar Entrada');
             }
+
+            if (!navigator.geolocation) { gpsFallo(); return; }
+            navigator.geolocation.getCurrentPosition(
+                function (pos) { enviar(pos.coords.latitude, pos.coords.longitude); },
+                function () { gpsFallo(); },
+                { enableHighAccuracy: true, timeout: 15000, maximumAge: 0 }
+            );
         }
 
-        function calcularRutaAsync(otOv, lat, lng) {
+        function calcularRutaAsync(otOv, lat, lng, idActividad) {
             $.ajax({
                 url: 'calcular_ruta.php',
                 method: 'POST',
-                data: { ov_ot: otOv, lat: lat, lng: lng }
+                data: { ov_ot: otOv, lat: lat, lng: lng, id_actividad: idActividad || 0 }
             });
         }
 

--- a/reportes/actualizar_todo.php
+++ b/reportes/actualizar_todo.php
@@ -7,16 +7,18 @@
  * Equivalente a correr secuencialmente:
  *   1) importar_scot.php          (segundos a minutos)
  *   2) geocodificar_clientes.php  (1.1 seg/cliente nuevo)
+ *   3) importar_otros.php         (carga Actividades sin OV/OT a la tabla `otros`, si hay CSV)
  */
 
 $php          = PHP_BINARY;
 $scriptImport = __DIR__ . '/importar_scot.php';
 $scriptGeo    = __DIR__ . '/geocodificar_clientes.php';
+$scriptOtros  = __DIR__ . '/importar_otros.php';
 
 $inicio = microtime(true);
 
 echo "============================================\n";
-echo " PASO 1/2 — Importar SCOT\n";
+echo " PASO 1/3 — Importar SCOT\n";
 echo "============================================\n";
 passthru(escapeshellarg($php) . ' ' . escapeshellarg($scriptImport), $rcImport);
 
@@ -26,13 +28,23 @@ if ($rcImport !== 0) {
 }
 
 echo "\n============================================\n";
-echo " PASO 2/2 — Geocodificar clientes\n";
+echo " PASO 2/3 — Geocodificar clientes\n";
 echo "============================================\n";
 passthru(escapeshellarg($php) . ' ' . escapeshellarg($scriptGeo), $rcGeo);
+
+echo "\n============================================\n";
+echo " PASO 3/3 — Importar Actividades (OTROS)\n";
+echo "============================================\n";
+if (glob(__DIR__ . '/DETALLE-OTROS_*.csv')) {
+    passthru(escapeshellarg($php) . ' ' . escapeshellarg($scriptOtros), $rcOtros);
+} else {
+    echo "Sin archivo DETALLE-OTROS_*.csv, se omite.\n";
+    $rcOtros = 0;
+}
 
 $total = round(microtime(true) - $inicio, 1);
 echo "\n============================================\n";
 echo " Proceso completo en {$total} seg.\n";
 echo "============================================\n";
 
-exit($rcGeo);
+exit($rcGeo !== 0 ? $rcGeo : $rcOtros);

--- a/reportes/importar_otros.php
+++ b/reportes/importar_otros.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Importador del archivo "Actividades" (OTROS) de SCOT -> tabla `otros`.
+ *
+ * Funciona como el importador OV/OT: lee el CSV y puebla una tabla. El cálculo
+ * de km NO ocurre aquí, sino en calcular_ruta.php al hacer check-in por QR
+ * (resuelve el cliente desde la tabla `otros` por usuario).
+ *
+ * Columnas del CSV (separador ','):
+ *   [0] IDUSR  [1] FeActividad (dd/mm/YYYY H:i)  [2] Actividad  [3] IDCliente
+ *   [7] DESCRIPCION  [8] latitude  [9] longitude  [12] order_code
+ *
+ * Se IGNORAN los renglones cuya Actividad sea CORREO o LLAMADA (no implican
+ * traslado). Se importan VISITA, APPVISITA, OTRO, etc.
+ *
+ * Uso CLI:  php reportes/importar_otros.php
+ * También es incluible: define las funciones sin ejecutar el bloque principal.
+ */
+
+if (!function_exists('archivoMasRecienteOtros')) {
+    function archivoMasRecienteOtros(string $dir, string $patron): ?string {
+        $matches = glob("$dir/$patron");
+        if (!$matches) return null;
+        usort($matches, function ($a, $b) { return filemtime($b) - filemtime($a); });
+        return $matches[0];
+    }
+}
+
+if (!function_exists('crearTablaOtros')) {
+    function crearTablaOtros(mysqli $conn): void {
+        $conn->query("CREATE TABLE IF NOT EXISTS otros (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            id_usuario INT NOT NULL,
+            fecha DATETIME NULL,
+            actividad VARCHAR(50) NOT NULL,
+            id_cliente INT NOT NULL,
+            descripcion VARCHAR(500) NULL,
+            latitude DECIMAL(10,7) NULL,
+            longitude DECIMAL(10,7) NULL,
+            order_code VARCHAR(50) NULL,
+            UNIQUE KEY uk_otros (id_usuario, fecha, actividad, id_cliente),
+            KEY idx_usuario (id_usuario),
+            KEY idx_order_code (order_code)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+    }
+}
+
+if (!function_exists('importarOtros')) {
+    /**
+     * Lee el CSV y puebla la tabla `otros`.
+     * @return array contadores: ok, ignoradas, dup, err
+     */
+    function importarOtros(mysqli $conn, string $archivoCsv, string $separador = ','): array {
+        $res = ['ok' => 0, 'ignoradas' => 0, 'dup' => 0, 'err' => 0];
+
+        // Actividades que NO implican traslado (se ignoran al leer el CSV)
+        $ACTIVIDADES_IGNORADAS = ['CORREO', 'LLAMADA'];
+
+        $gestor = @fopen($archivoCsv, 'r');
+        if (!$gestor) { $res['err']++; return $res; }
+        fgetcsv($gestor, 0, $separador); // omitir encabezado
+
+        crearTablaOtros($conn);
+        $stmt = $conn->prepare("INSERT IGNORE INTO otros
+            (id_usuario, fecha, actividad, id_cliente, descripcion, latitude, longitude, order_code)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)");
+
+        $conn->begin_transaction();
+        while (($d = fgetcsv($gestor, 0, $separador)) !== false) {
+            try {
+                $idUsr     = isset($d[0])  ? intval(trim($d[0]))  : 0;
+                $feRaw     = isset($d[1])  ? trim($d[1])          : '';
+                $actividad = isset($d[2])  ? trim($d[2])          : '';
+                $idCliente = isset($d[3])  ? intval(trim($d[3]))  : 0;
+                $descrip   = isset($d[7])  ? trim($d[7])          : '';
+                $latRaw    = isset($d[8])  ? trim($d[8])          : '';
+                $lngRaw    = isset($d[9])  ? trim($d[9])          : '';
+                $orderCode = isset($d[12]) ? trim($d[12])         : '';
+
+                if ($idUsr <= 0 || $idCliente <= 0 || $actividad === '') { $res['err']++; continue; }
+
+                // Ignorar actividades sin traslado (CORREO, LLAMADA)
+                if (in_array(strtoupper($actividad), $ACTIVIDADES_IGNORADAS, true)) { $res['ignoradas']++; continue; }
+
+                // Coordenadas de la actividad (pueden venir vacías) y metadatos
+                $lat       = ($latRaw !== '' && is_numeric($latRaw)) ? floatval($latRaw) : null;
+                $lng       = ($lngRaw !== '' && is_numeric($lngRaw)) ? floatval($lngRaw) : null;
+                $descrip   = $descrip   !== '' ? mb_substr($descrip, 0, 500) : null;
+                $orderCode = $orderCode !== '' ? $orderCode : null;
+
+                // Fecha + hora. El CSV trae "d/m/Y H:i:s" (a veces con doble
+                // espacio entre fecha y hora). Se normaliza el espaciado y se
+                // intenta con hora; si no trae hora, se cae a solo fecha.
+                $fechaSql = null;
+                if ($feRaw !== '') {
+                    $feNorm = preg_replace('/\s+/', ' ', $feRaw);
+                    $dt = DateTime::createFromFormat('d/m/Y H:i:s', $feNorm)
+                        ?: DateTime::createFromFormat('d/m/Y H:i', $feNorm)
+                        ?: DateTime::createFromFormat('!d/m/Y', substr($feNorm, 0, 10));
+                    if ($dt) $fechaSql = $dt->format('Y-m-d H:i:s');
+                }
+
+                $stmt->bind_param("issisdds", $idUsr, $fechaSql, $actividad, $idCliente, $descrip, $lat, $lng, $orderCode);
+                $stmt->execute();
+                if ($stmt->affected_rows > 0) $res['ok']++; else $res['dup']++;
+            } catch (Throwable $e) {
+                $res['err']++;
+            }
+        }
+        $conn->commit();
+
+        $stmt->close();
+        fclose($gestor);
+        return $res;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bloque principal (solo cuando se invoca directamente por CLI)
+// ---------------------------------------------------------------------------
+if (PHP_SAPI === 'cli' && realpath($_SERVER['SCRIPT_FILENAME'] ?? '') === realpath(__FILE__)) {
+    include __DIR__ . '/../conn.php';
+    mysqli_set_charset($conn, "utf8mb4");
+    date_default_timezone_set('America/Mexico_City');
+
+    $archivo = archivoMasRecienteOtros(__DIR__, 'DETALLE-OTROS_*.csv');
+    if (!$archivo) {
+        echo "ERROR: no se encontró DETALLE-OTROS_*.csv en " . __DIR__ . "\n";
+        exit(1);
+    }
+
+    echo "Importando " . basename($archivo) . " -> tabla otros\n";
+
+    $inicio = microtime(true);
+    $r = importarOtros($conn, $archivo);
+    $dur = round(microtime(true) - $inicio, 1);
+
+    echo "\nResumen OTROS:\n";
+    echo "  Importadas:            {$r['ok']}\n";
+    echo "  Ignoradas (corr/llam): {$r['ignoradas']}\n";
+    echo "  Duplicadas:            {$r['dup']}\n";
+    echo "  Errores:               {$r['err']}\n";
+    echo "  Tiempo:                {$dur} seg\n";
+
+    // Reconciliar check-ins que quedaron sin km (actividad subida después).
+    require_once __DIR__ . '/../calcular_ruta.php';
+    $rc = reconciliarKmPendientes($conn);
+    echo "\nReconciliación de check-ins pendientes:\n";
+    echo "  Revisados:     {$rc['revisados']}\n";
+    echo "  Calculados:    {$rc['calculados']}\n";
+    echo "  Sin actividad: {$rc['sin_actividad']}\n";
+    echo "  Sin destino:   {$rc['sin_destino']}\n";
+    echo "  OV/OT (omit.): {$rc['ovot']}\n";
+
+    $conn->close();
+}


### PR DESCRIPTION
- importar_otros.php: parsea fecha+hora del CSV DETALLE-OTROS y guarda descripcion/coordenadas/order_code en `otros`
- calcular_ruta.php: resuelve cliente/destino de OTROS (mismo día), excluye destinos dentro de 3km de sedes MESS, cascada de escalas INEGI, y UPSERT en km_calculados (placeholder 'sin_actividad' que se rellena al reconciliar)
- check-in QR y modal global: GPS obligatorio, registran origen y calculan km
- actividad_vehiculo: ot solo OV/OT, tipo de actividad en detalle_tipo_uso, order_code de OTROS
- reconciliarKmPendientes(): batch al importar FactActividades llena los check-ins sin match previo