### PR TITLE
Limpieza post-debug y mejoras UX en módulo QR

### DIFF
--- a/qr_vehiculo.php
+++ b/qr_vehiculo.php
@@ -314,6 +314,11 @@ if (empty($_COOKIE['noEmpleado'])) {
         var ultimoKMVehiculo = 0;
 
         $(document).ready(function () {
+            if ($(window).width() < 768) {
+                $('.sidebar').addClass('toggled');
+                $('body').addClass('sidebar-toggled');
+            }
+
             cargarVehiculo();
 
             // Preview de foto al seleccionar
@@ -463,9 +468,6 @@ if (empty($_COOKIE['noEmpleado'])) {
                     $('#loadingQR').hide();
                     $('#cardVehiculo, #cardAcciones, #cardEstatus, #cardDocumentacion').show();
 
-                    // Registrar préstamo automático si el vehículo no es del usuario
-                    $.post('acciones_qr.php', { accion: 'registrarPrestamoQR', id_vehiculo: idVehiculo }, function () {}, 'json')
-                        .fail(function () { console.warn('No se pudo registrar préstamo automático.'); });
                 },
                 error: function () {
                     $('#loadingQR').html('<div class="alert alert-danger">No se pudo cargar la información del vehículo.</div>');
@@ -778,6 +780,8 @@ if (empty($_COOKIE['noEmpleado'])) {
                             if (latNum != null && lngNum != null) {
                                 calcularRutaAsync(otOv, latNum, lngNum, resp.id_actividad);
                             }
+
+                            $.post('acciones_qr.php', { accion: 'registrarPrestamoQR', id_vehiculo: idVehiculo }, function () {}, 'json');
                         } else {
                             Swal.fire({ icon: 'error', title: 'Error', text: resp.error || 'No se pudo registrar.', confirmButtonText: 'Aceptar' });
                         }


### PR DESCRIPTION
- Revertido Swal diagnóstico a mensaje genérico
- Sidebar se colapsa automáticamente en pantallas móviles al abrir QR
- Préstamo automático se registra solo después de un check-in exitoso, no al cargar la página
- conn.php simplificado: eliminada conexión procedimental duplicada