### PR TITLE
auto-cierre de check-in

### DIFF
--- a/acciones_qr.php
+++ b/acciones_qr.php
@@ -294,6 +294,34 @@ if ($accion === 'checkInQR') {
         exit;
     }
 
+    // Auto-cerrar check-in anterior si existe (INICIO sin FINALIZACION posterior)
+    $stmtChk = $conn->prepare("
+        SELECT id_actividad FROM actividad_vehiculo
+        WHERE id_usuario = ? AND id_vehiculo = ?
+          AND tipo_actividad = 'INICIO'
+          AND fecha_actividad = (
+              SELECT MAX(fecha_actividad) FROM actividad_vehiculo
+              WHERE id_usuario = ? AND id_vehiculo = ?
+          )
+        LIMIT 1
+    ");
+    $stmtChk->bind_param("iiii", $id_usuario_cookie, $id_vehiculo, $id_usuario_cookie, $id_vehiculo);
+    $stmtChk->execute();
+    $checkinAbierto = $stmtChk->get_result()->fetch_assoc();
+    $stmtChk->close();
+
+    if ($checkinAbierto) {
+        $stmtCierre = $conn->prepare("INSERT INTO actividad_vehiculo (id_vehiculo, id_usuario, km_actual, coordenadas, fecha_actividad, tipo_actividad) VALUES (?, ?, ?, ?, NOW(), 'FINALIZACION')");
+        $stmtCierre->bind_param("iiis", $id_vehiculo, $id_usuario_cookie, $km_actual, $coordenadas);
+        $stmtCierre->execute();
+        $stmtCierre->close();
+
+        $stmtPrest = $conn->prepare("UPDATE prestamos SET estatus = 'FINALIZADO', fecha_fin_prestamo = NOW() WHERE id_usuario = ? AND id_vehiculo = ? AND estatus = 'EN CURSO'");
+        $stmtPrest->bind_param("ii", $id_usuario_cookie, $id_vehiculo);
+        $stmtPrest->execute();
+        $stmtPrest->close();
+    }
+
     $placa     = obtenerPlacaVehiculo($conn, $id_vehiculo);
     $ruta_foto = subirFotoKM($placa, 'checkin');
 

--- a/encabezado.php
+++ b/encabezado.php
@@ -298,7 +298,7 @@
                         <div class="mb-2 row g-2">    
                             <div class="col-4 col-md-4">
                                 <label for="monto" class="form-label">Monto</label>
-                                <input type="text" class="form-control" id="monto" name="monto" placeholder="$00.00" required>
+                                <input type="text" class="form-control" id="monto" name="monto" placeholder="$00.00" readonly required>
                             </div>
                         
                             <div class="col-4 col-md-4">
@@ -308,7 +308,7 @@
 
                             <div class="col-4 col-md-4">
                                 <label for="saldo" class="form-label">Saldo</label>
-                                <input type="number" class="form-control" id="saldo" name="saldo" placeholder="$00.00" required>
+                                <input type="number" class="form-control" id="saldo" name="saldo" placeholder="$00.00" readonly required>
                             </div>
                         </div>
                         <div class="mb-2 row g-2">

--- a/qr_vehiculo.php
+++ b/qr_vehiculo.php
@@ -142,7 +142,7 @@ if (empty($_COOKIE['noEmpleado'])) {
                                     <button class="btn btn-outline-primary w-100 action-btn"
                                         id="btnCheckinKM" data-bs-toggle="modal" data-bs-target="#modalCheckinKM">
                                         <i class="far fa-check-square"></i>
-                                        Check-In / Out
+                                        Check-In
                                     </button>
                                 </div>
 
@@ -208,12 +208,12 @@ if (empty($_COOKIE['noEmpleado'])) {
         </div>
     </div>
 
-    <!-- Modal: Check-In / Out + KM (combinado) -->
+    <!-- Modal: Check-In + KM (combinado) -->
     <div class="modal fade" id="modalCheckinKM" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content">
                 <div class="modal-header border-0 pb-1">
-                    <h5 class="modal-title fw-bold" id="modalCheckinKMLabel">Check-In / Out</h5>
+                    <h5 class="modal-title fw-bold" id="modalCheckinKMLabel">Check-In</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
                 </div>
                 <div class="modal-body pt-2">
@@ -336,17 +336,16 @@ if (empty($_COOKIE['noEmpleado'])) {
 
             // Modal checkin/km: cargar estado al abrirse
             document.getElementById('modalCheckinKM').addEventListener('show.bs.modal', function () {
-                $('#modalCheckinKMLabel').text('Check-In / Out');
+                $('#modalCheckinKMLabel').text('Check-In');
                 $('#checkinMensaje').text('Verificando estado...');
                 $('#btnGuardarCheckinKM').prop('disabled', true).text('Verificando...');
 
                 var ajaxListo = { estado: false, km: false };
                 function habilitarSiListo() {
                     if (ajaxListo.estado && ajaxListo.km) {
-                        var esCheckout = checkinEstado.tieneCheckinActivo;
                         $('#btnGuardarCheckinKM')
                             .prop('disabled', false)
-                            .text(esCheckout ? 'Registrar Salida' : 'Registrar Entrada');
+                            .text('Registrar Entrada');
                     }
                 }
 
@@ -357,13 +356,8 @@ if (empty($_COOKIE['noEmpleado'])) {
                     data: { accion: 'verificarEstadoCheckin', id_vehiculo: idVehiculo },
                     success: function (resp) {
                         checkinEstado = resp;
-                        var esCheckout = resp.tieneCheckinActivo;
-                        $('#modalCheckinKMLabel').text(esCheckout ? 'Check-Out' : 'Check-In');
-                        $('#checkinMensaje').text(
-                            esCheckout
-                                ? 'Ya tienes una entrada activa para este vehículo. ¿Registras tu salida?'
-                                : '¿Confirmas tu entrada para este vehículo?'
-                        );
+                        $('#modalCheckinKMLabel').text('Check-In');
+                        $('#checkinMensaje').text('¿Confirmas tu entrada para este vehículo?');
                         $('#checkinFotoSection').toggle(resp.primerKMDeLaSemana === true);
                         ajaxListo.estado = true;
                         habilitarSiListo();
@@ -601,9 +595,14 @@ if (empty($_COOKIE['noEmpleado'])) {
                         select.append($('<option>', { value: item.id_vehiculo, text: item.placa + ' - ' + item.modelo }));
                     });
                     select.val(idVeh);
+                    select.prop('disabled', true);
                     // Disparar el onchange para que verPlaca() cargue km, gasolina y el último saldo en Monto
                     select.trigger('change');
-                    new bootstrap.Modal(document.getElementById('capturaGasModal')).show();
+                    var modalEl = document.getElementById('capturaGasModal');
+                    modalEl.addEventListener('hidden.bs.modal', function () {
+                        select.prop('disabled', false);
+                    }, { once: true });
+                    new bootstrap.Modal(modalEl).show();
                 },
                 error: function () {
                     Swal.fire({ icon: 'error', title: 'Error', text: 'No se pudo cargar los vehículos.', confirmButtonText: 'Aceptar' });
@@ -718,7 +717,6 @@ if (empty($_COOKIE['noEmpleado'])) {
         }
 
         function guardarCheckinKM() {
-            var esCheckout = checkinEstado.tieneCheckinActivo;
             var km   = $('#checkinKM').val().trim();
             var otOv = $('#checkinOT').val().trim();
 
@@ -743,7 +741,7 @@ if (empty($_COOKIE['noEmpleado'])) {
                 var coordenadas = (latNum != null && lngNum != null) ? (latNum + ',' + lngNum) : '';
 
                 var formData = new FormData();
-                formData.append('accion', esCheckout ? 'checkOutQR' : 'checkInQR');
+                formData.append('accion', 'checkInQR');
                 formData.append('id_vehiculo', idVehiculo);
                 formData.append('coordenadas', coordenadas);
                 formData.append('km_actual', km);
@@ -764,7 +762,7 @@ if (empty($_COOKIE['noEmpleado'])) {
                     success: function (resp) {
                         if (resp.success) {
                             var modalEl = document.getElementById('modalCheckinKM');
-                            var msg = esCheckout ? 'Salida registrada correctamente.' : 'Entrada registrada correctamente.';
+                            var msg = 'Entrada registrada correctamente.';
                             modalEl.addEventListener('hidden.bs.modal', function () {
                                 document.querySelectorAll('.modal-backdrop').forEach(function (el) { el.remove(); });
                                 document.body.classList.remove('modal-open');
@@ -792,7 +790,7 @@ if (empty($_COOKIE['noEmpleado'])) {
                         Swal.fire({ icon: 'error', title: 'Error', text: detalle, confirmButtonText: 'Aceptar' });
                     },
                     complete: function () {
-                        $('#btnGuardarCheckinKM').prop('disabled', false).text(esCheckout ? 'Registrar Salida' : 'Registrar Entrada');
+                        $('#btnGuardarCheckinKM').prop('disabled', false).text('Registrar Entrada');
                     }
                 });
                 }); // fin promesaFoto.then
@@ -806,7 +804,7 @@ if (empty($_COOKIE['noEmpleado'])) {
                     text: 'No pudimos obtener tu ubicación, que es obligatoria para registrar el check-in. Habilita el GPS y el permiso de ubicación del navegador e inténtalo de nuevo.',
                     confirmButtonText: 'Reintentar'
                 });
-                $('#btnGuardarCheckinKM').prop('disabled', false).text(esCheckout ? 'Registrar Salida' : 'Registrar Entrada');
+                $('#btnGuardarCheckinKM').prop('disabled', false).text('Registrar Entrada');
             }
 
             if (!navigator.geolocation) { gpsFallo(); return; }


### PR DESCRIPTION
- Check-in desde QR ahora auto-cierra el INICIO previo (inserta FINALIZACION) y finaliza el préstamo EN CURSO antes de registrar el nuevo INICIO
- Botón y modal de QR solo muestran "Check-In" (se elimina flujo de checkout)
- Campos monto y saldo en modal de gasolina ahora son readonly
- Select de vehículo en modal de gas se bloquea al abrir desde QR