### PR TITLE
Historial por vehículo, monto gas y validaciones + fixes varios

### DIFF
--- a/acciones_gas.php
+++ b/acciones_gas.php
@@ -15,6 +15,66 @@ $km_actual = isset($_POST['km_actual']) ? $_POST['km_actual'] : null;
 $fecha_carga = isset($_POST['fecha_carga']) ? $_POST['fecha_carga'] : null;
 $fecha_registro = isset($_POST['fecha_registro']) ? $_POST['fecha_registro'] : null;
 
+    /**
+     * Conjunto de vehículos que el usuario puede consultar en gasolina.
+     * Replica el criterio de consultarInventario (acciones_siniestro.php):
+     * super usuario = acceso registrarMantenimiento con inf_adicional='TODAS'.
+     * Devuelve ['todas'=>bool, 'ids'=>int[]].
+     */
+    function vehiculosPermitidosGas($conn, $id_usuario, $noEmpleado) {
+        $id_usuario = intval($id_usuario);
+        $noEmpleado = intval($noEmpleado);
+
+        $infAdicional = null;
+        $stmtReg = $conn->prepare("SELECT inf_adicional FROM mess_rrhh.accesos_especiales WHERE noEmpleado = ? AND sistema = 'ctrlVehicular' AND opcion = 'registrarMantenimiento' AND estatus = 1 LIMIT 1");
+        if ($stmtReg) {
+            $stmtReg->bind_param("i", $noEmpleado);
+            $stmtReg->execute();
+            $rowReg = $stmtReg->get_result()->fetch_assoc();
+            if ($rowReg && !empty($rowReg['inf_adicional']) && $rowReg['inf_adicional'] !== '-') {
+                $infAdicional = trim($rowReg['inf_adicional']);
+            }
+            $stmtReg->close();
+        }
+
+        if ($infAdicional === 'TODAS') {
+            return ['todas' => true, 'ids' => []];
+        }
+
+        $areas = [];
+        $deptos = [];
+        if ($infAdicional) {
+            foreach (array_map('trim', explode(',', $infAdicional)) as $item) {
+                if (stripos($item, 'LAB:') === 0) {
+                    $id = (int) substr($item, 4);
+                    if ($id > 0) $deptos[] = $id;
+                } else {
+                    $areas[] = $conn->real_escape_string($item);
+                }
+            }
+        }
+
+        $sql = "SELECT inv.id_vehiculo FROM inventario inv
+                WHERE inv.id_us_asignado = $id_usuario OR inv.id_usuario = $id_usuario
+                UNION
+                SELECT inv.id_vehiculo FROM prestamos p
+                INNER JOIN inventario inv ON p.id_vehiculo = inv.id_vehiculo
+                WHERE p.id_usuario = $id_usuario AND p.estatus = 'AUTORIZADO'";
+        if (!empty($areas)) {
+            $areasEsc = implode("','", $areas);
+            $sql .= " UNION SELECT inv.id_vehiculo FROM inventario inv WHERE inv.area IN ('$areasEsc')";
+        }
+        if (!empty($deptos)) {
+            $deptosEsc = implode(',', $deptos);
+            $sql .= " UNION SELECT inv.id_vehiculo FROM inventario inv INNER JOIN usuarios us ON inv.id_usuario = us.id_usuario WHERE us.departamento IN ($deptosEsc)";
+        }
+
+        $ids = [];
+        $res = $conn->query($sql);
+        if ($res) { while ($r = $res->fetch_assoc()) { $ids[] = intval($r['id_vehiculo']); } }
+        return ['todas' => false, 'ids' => $ids];
+    }
+
     //FUNCION PARA REGISTRAR CARGA
     if ($accion == 'registraGas'){
         $sqlR = "INSERT INTO carga_gasolina (`id_usuario`, `id_vehiculo`, `monto`, `pagos`, `saldo`, `km_actual`, `fecha_carga`, `fecha_registro`) 
@@ -75,8 +135,20 @@ $fecha_registro = isset($_POST['fecha_registro']) ? $_POST['fecha_registro'] : n
         exit;
     }
 
-    // Historial completo con km_consumidos calculado
+    // Historial de UN vehículo (tarjeta de gas por vehículo) con km_consumidos calculado
     if ($accion == 'obtenerHistorialGas') {
+        $idVeh = isset($_POST['id_vehiculo']) ? intval($_POST['id_vehiculo']) : 0;
+
+        // La vista es por-vehículo: sin vehículo no se devuelve nada.
+        if ($idVeh <= 0) { echo json_encode([]); exit; }
+
+        // Salvaguarda anti-IDOR: solo vehículos permitidos (asignados, o todos si super).
+        $perm = vehiculosPermitidosGas($conn, $id_usuario, $noEmpleado);
+        if (!$perm['todas'] && !in_array($idVeh, $perm['ids'], true)) {
+            echo json_encode([]);
+            exit;
+        }
+
         $sqlU = "SELECT
                     cg.*,
                     CONCAT(inv.placa, ' - ', inv.modelo, ' ', inv.marca) AS Vehiculo,
@@ -92,18 +164,60 @@ $fecha_registro = isset($_POST['fecha_registro']) ? $_POST['fecha_registro'] : n
                  INNER JOIN inventario inv ON inv.id_vehiculo = cg.id_vehiculo
                  LEFT JOIN usuarios u ON u.id_usuario = cg.id_usuario
                  LEFT JOIN mess_rrhh.usuarios rrhh ON rrhh.noEmpleado = u.noEmpleado
+                 WHERE cg.id_vehiculo = ?
                  ORDER BY cg.id DESC";
 
-        $resultU = $conn->query($sqlU);
         $registros = [];
-        if ($resultU) {
+        $stmt = $conn->prepare($sqlU);
+        if ($stmt) {
+            $stmt->bind_param("i", $idVeh);
+            $stmt->execute();
+            $resultU = $stmt->get_result();
             while ($row = $resultU->fetch_assoc()) {
                 $registros[] = $row;
             }
+            $stmt->close();
             echo json_encode($registros);
         } else {
             echo json_encode(['status' => 'error', 'message' => $conn->error]);
         }
+        exit;
+    }
+
+    // Vehículo a precargar en el historial: el de más km recorridos del usuario
+    // (o el de más km global si es super). Fallback: primer vehículo asignado.
+    if ($accion == 'vehiculoPrincipalGas') {
+        $perm = vehiculosPermitidosGas($conn, $id_usuario, $noEmpleado);
+        $idElegido = 0;
+
+        if ($perm['todas']) {
+            $res = $conn->query("SELECT id_vehiculo FROM reporte_km_vehiculo GROUP BY id_vehiculo ORDER BY SUM(km_registrado) DESC LIMIT 1");
+            if ($res && ($row = $res->fetch_assoc())) { $idElegido = intval($row['id_vehiculo']); }
+            if (!$idElegido) {
+                $res2 = $conn->query("SELECT id_vehiculo FROM inventario WHERE estatus = 'Activo' ORDER BY id_vehiculo LIMIT 1");
+                if ($res2 && ($row2 = $res2->fetch_assoc())) { $idElegido = intval($row2['id_vehiculo']); }
+            }
+        } else {
+            $ids = $perm['ids'];
+            if (!empty($ids)) {
+                $idsEsc = implode(',', array_map('intval', $ids));
+                $res = $conn->query("SELECT id_vehiculo FROM reporte_km_vehiculo WHERE id_vehiculo IN ($idsEsc) GROUP BY id_vehiculo ORDER BY SUM(km_registrado) DESC LIMIT 1");
+                if ($res && ($row = $res->fetch_assoc())) { $idElegido = intval($row['id_vehiculo']); }
+                if (!$idElegido) { $idElegido = intval($ids[0]); } // fallback: primero asignado
+            }
+        }
+
+        $placaElegida = '';
+        if ($idElegido) {
+            $stmtP = $conn->prepare("SELECT placa FROM inventario WHERE id_vehiculo = ? LIMIT 1");
+            $stmtP->bind_param("i", $idElegido);
+            $stmtP->execute();
+            $rp = $stmtP->get_result()->fetch_assoc();
+            $placaElegida = $rp ? $rp['placa'] : '';
+            $stmtP->close();
+        }
+
+        echo json_encode(['id_vehiculo' => $idElegido, 'placa' => $placaElegida]);
         exit;
     }
 

--- a/acciones_kilometraje.php
+++ b/acciones_kilometraje.php
@@ -47,16 +47,27 @@ if (isset($_FILES['foto']) && $_FILES['foto']['error'] == UPLOAD_ERR_OK) {
 
 if ($accion == 'CargarVehiculos'){
 
+        // Resolver el id de usuario de forma robusta: preferir id_usuarioL (el id de
+        // CV que setea el login) y caer a id_usuario si aquel viene vacío. Antes usaba
+        // solo id_usuario, que en algunas sesiones venía vacío -> 0 filas -> error.
+        $idU = intval($_COOKIE['id_usuarioL'] ?? 0);
+        if ($idU <= 0) { $idU = intval($_COOKIE['id_usuario'] ?? 0); }
+        if ($idU <= 0) {
+            // Sin usuario válido no se consulta (evita hacer match con id_usuario=0 = S/A).
+            echo json_encode(['status' => 'error', 'message' => 'No se encontraron vehículos activos.']);
+            exit;
+        }
+
         $sql = "SELECT id_vehiculo, placa, marca, modelo, color, '' as id_prestamo, '' as estatus
-            FROM inventario Where id_usuario = '".$_COOKIE['id_usuario']."' OR id_us_asignado = '".$_COOKIE['id_usuario']."'
+            FROM inventario Where id_usuario = $idU OR id_us_asignado = $idU
             UNION
             SELECT inv.id_vehiculo, inv.placa, inv.marca, inv.modelo, inv.color, p.id_prestamo, p.estatus
             FROM inventario inv
             INNER JOIN prestamos p ON inv.id_vehiculo = p.id_vehiculo
-            WHERE (p.id_usuario = '".$_COOKIE['id_usuario']."') AND (p.estatus = 'AUTORIZADO' OR p.estatus = 'EN CURSO')";
+            WHERE (p.id_usuario = $idU) AND (p.estatus = 'AUTORIZADO' OR p.estatus = 'EN CURSO')";
     $result = $conn->query($sql);
-    
-    if ($result->num_rows > 0) {
+
+    if ($result && $result->num_rows > 0) {
         $vehiculos = [];
         while ($row = $result->fetch_assoc()) {
             $vehiculos[] = $row;
@@ -89,33 +100,35 @@ if ($accion == 'CargarVehiculosPTenencia'){
 
 
 if ($accion == 'tomaKm'){
-    
-    $IDvehiculoAsignado = isset($_POST['IDvehiculoAsignado']) ? $_POST['IDvehiculoAsignado'] : null;
-    
-    // Consultar los vehículos activos del usuario actual
-    $sql = "SELECT av.gasolina_actual, av.km_actual AS kmMax, cg.saldo
-            FROM actividad_vehiculo av 
-            INNER JOIN carga_gasolina cg ON av.id_vehiculo = cg.id_vehiculo
-            WHERE av.id_vehiculo = $IDvehiculoAsignado 
-                AND cg.id = (
-                    SELECT MAX(id)
-                    FROM carga_gasolina
-                    WHERE id_vehiculo = $IDvehiculoAsignado
-                )
-            ORDER BY av.km_actual DESC
-            LIMIT 1";
-            
+
+    $IDvehiculoAsignado = intval($_POST['IDvehiculoAsignado'] ?? 0);
+
+    // Subconsultas escalares independientes: SIEMPRE devuelve 1 fila (con NULL donde
+    // no haya datos). Antes usaba INNER JOIN actividad_vehiculo + carga_gasolina, que
+    // devolvía 0 filas (y error) si el vehículo aún no tenía actividad NI cargas.
+    //   kmMax           = último odómetro registrado en actividad
+    //   gasolina_actual = nivel de gasolina de la última actividad
+    //   saldo           = saldo de la última carga de gasolina (si hay)
+    $sql = "SELECT
+                (SELECT av.km_actual FROM actividad_vehiculo av
+                 WHERE av.id_vehiculo = $IDvehiculoAsignado
+                 ORDER BY av.km_actual DESC LIMIT 1) AS kmMax,
+                (SELECT av.gasolina_actual FROM actividad_vehiculo av
+                 WHERE av.id_vehiculo = $IDvehiculoAsignado
+                 ORDER BY av.id_actividad DESC LIMIT 1) AS gasolina_actual,
+                (SELECT cg.saldo FROM carga_gasolina cg
+                 WHERE cg.id_vehiculo = $IDvehiculoAsignado
+                 ORDER BY cg.id DESC LIMIT 1) AS saldo";
+
     $result = $conn->query($sql);
 
-    if ($result->num_rows > 0) {
-        $vehiculos = [];
+    $vehiculos = [];
+    if ($result) {
         while ($row = $result->fetch_assoc()) {
             $vehiculos[] = $row;
         }
-        echo json_encode($vehiculos);
-    } else {
-        echo json_encode(['status' => 'error', 'message' => 'No se encontraron vehículos activos.']);
     }
+    echo json_encode($vehiculos);
     exit;
 }
 

--- a/acciones_ver_registros.php
+++ b/acciones_ver_registros.php
@@ -206,6 +206,7 @@ if ($_POST['accion'] == 'verMantenimientoXVehiculo') {
     exit;
 }
 
+// Actualiza el estado de mantenimiento a "REALIZADO"
 if($_POST['accion'] == 'mantenimientoRealizado'){
     $id_mantenimiento = $_POST['id_mantenimiento'];
     $sql = "UPDATE mantenimientos SET VoBo_jefe = 'REALIZADO' WHERE id_mantenimiento = $id_mantenimiento";

--- a/checkVehiculo.php
+++ b/checkVehiculo.php
@@ -870,8 +870,12 @@ if ($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null) {
 
         function verificarCompletitud() {
             var inputs = document.querySelectorAll('input[type="file"][name^="foto_"]');
+            var dots = document.querySelectorAll('.chk-dot');
             inputs.forEach(function(input, idx) {
-                if (pasoTieneFoto(idx)) marcarDotLleno(idx);
+                // Sincroniza el verde con el estado real: verde SOLO si el apartado
+                // tiene foto. Antes solo agregaba (marcarDotLleno) y nunca quitaba, por
+                // eso al borrar una foto el punto seguía marcado verde como completo.
+                if (dots[idx]) dots[idx].classList.toggle('filled', pasoTieneFoto(idx));
             });
         }
 

--- a/encabezado.php
+++ b/encabezado.php
@@ -305,7 +305,7 @@
                         
                             <div class="col-4 col-md-4">
                                 <label for="pagos" class="form-label">Pagos</label>
-                                <input type="text" class="form-control" id="pagos" name="pagos" placeholder="$00.00" onblur="calcularSaldo()" required>
+                                <input type="text" class="form-control" id="pagos" name="pagos" placeholder="$00.00" oninput="calcularSaldo()" required>
                             </div>
 
                             <div class="col-4 col-md-4">

--- a/historial_gasolina.php
+++ b/historial_gasolina.php
@@ -32,10 +32,10 @@ if (empty($_COOKIE['noEmpleado'])) {
                 <div class="d-sm-flex align-items-center justify-content-between mb-3">
                     <h1 class="h3 mb-0 text-gray-800">Historial de Cargas de Gasolina</h1>
                     <div class="d-flex gap-2">
-                        <button class="btn btn-outline-warning btn-sm" onclick="descargarTabla()">
+                        <button id="btnDescargar" class="btn btn-outline-warning btn-sm" onclick="descargarTabla()" disabled>
                             <i class="fas fa-file-excel me-1"></i> Descargar XLSX
                         </button>
-                        <button class="btn btn-primary btn-sm" onclick="solicitarReposicionGeneral()">
+                        <button id="btnReposicion" class="btn btn-primary btn-sm" onclick="solicitarReposicionVehiculo()" disabled>
                             <i class="fas fa-gas-pump me-1"></i> Solicitar reposición de crédito
                         </button>
                     </div>
@@ -44,22 +44,11 @@ if (empty($_COOKIE['noEmpleado'])) {
                 <div class="card shadow mb-4">
                     <div class="card-header bg-white py-2">
                         <div class="row g-2 align-items-end">
-                            <div class="col-12 col-md-4">
-                                <label class="form-label small mb-1">Filtrar por vehículo</label>
+                            <div class="col-12 col-md-6">
+                                <label class="form-label small mb-1">Vehículo (tarjeta de gas)</label>
                                 <select id="filtroVehiculo" class="form-select form-select-sm">
-                                    <option value="">Todos los vehículos</option>
+                                    <option value="">Selecciona un vehículo</option>
                                 </select>
-                            </div>
-                            <div class="col-12 col-md-4">
-                                <label class="form-label small mb-1">Filtrar por usuario</label>
-                                <select id="filtroUsuario" class="form-select form-select-sm">
-                                    <option value="">Todos los usuarios</option>
-                                </select>
-                            </div>
-                            <div class="col-12 col-md-4">
-                                <button class="btn btn-outline-secondary btn-sm" onclick="limpiarFiltros()">
-                                    <i class="fas fa-times me-1"></i> Limpiar filtros
-                                </button>
                             </div>
                         </div>
                     </div>
@@ -107,17 +96,9 @@ if (empty($_COOKIE['noEmpleado'])) {
 
 <script>
 var tabla;
-var datosGas = [];
-
-// Filtros personalizados por columna (índice 0=vehículo, 1=usuario)
-$.fn.dataTable.ext.search.push(function(settings, data) {
-    if (settings.nTable.id !== 'tablaGas') return true;
-    var filtroV = $('#filtroVehiculo').val();
-    var filtroU = $('#filtroUsuario').val();
-    if (filtroV && data[0].indexOf(filtroV) === -1) return false;
-    if (filtroU && data[1].indexOf(filtroU) === -1) return false;
-    return true;
-});
+var idVehSel = 0;
+var placaSel = '';
+var saldoSel = 0;
 
 $(document).ready(function () {
     tabla = $('#tablaGas').DataTable({
@@ -134,6 +115,7 @@ $(document).ready(function () {
         language: {
             lengthMenu: "Mostrar _MENU_ registros",
             zeroRecords: "No se encontraron resultados",
+            emptyTable: "Selecciona un vehículo para ver su tarjeta de gas",
             info: "Mostrando _START_ a _END_ de _TOTAL_ registros",
             infoEmpty: "Sin registros disponibles",
             infoFiltered: "(filtrado de _MAX_ totales)",
@@ -142,52 +124,98 @@ $(document).ready(function () {
         }
     });
 
-    cargarHistorial();
+    // El select se llena con los vehículos asignados (o todos si super usuario),
+    // igual que mantenimiento; al cargar se precarga uno automáticamente.
+    cargarSelectVehiculos(preseleccionarVehiculo);
 
-    $('#filtroVehiculo, #filtroUsuario').on('change', function () {
-        tabla.draw();
-    });
+    $('#filtroVehiculo').on('change', cargarHistorialVehiculo);
 });
 
-function cargarHistorial() {
+// Llena el select con consultarInventario (asignados / todos), como mantenimiento
+function cargarSelectVehiculos(callback) {
+    $.ajax({
+        url: 'acciones_siniestro',
+        type: 'POST',
+        data: { accion: 'consultarInventario' },
+        dataType: 'json',
+        success: function (data) {
+            var sel = $('#filtroVehiculo');
+            sel.empty().append('<option value="">Selecciona un vehículo</option>');
+            if (Array.isArray(data)) {
+                data.forEach(function (v) {
+                    sel.append('<option value="' + v.id_vehiculo + '" data-placa="' + escHtml(v.placa) + '">'
+                        + escHtml(v.placa) + ' - ' + escHtml(v.modelo) + ' ' + escHtml(v.marca) + '</option>');
+                });
+            }
+            if (typeof callback === 'function') callback();
+        },
+        error: function () {
+            Swal.fire({ icon: 'error', title: 'Error', text: 'No se pudo cargar la lista de vehículos.' });
+        }
+    });
+}
+
+// Precarga: 1 vehículo -> ese; varios -> el de más km recorridos (vehiculoPrincipalGas)
+function preseleccionarVehiculo() {
+    var opciones = $('#filtroVehiculo option').filter(function () { return this.value !== ''; });
+    if (opciones.length === 0) { cargarHistorialVehiculo(); return; }
+    if (opciones.length === 1) {
+        $('#filtroVehiculo').val(opciones.first().val());
+        cargarHistorialVehiculo();
+        return;
+    }
     $.ajax({
         url: 'acciones_gas.php',
         type: 'POST',
-        data: { accion: 'obtenerHistorialGas' },
+        data: { accion: 'vehiculoPrincipalGas' },
+        dataType: 'json',
+        success: function (resp) {
+            var id = (resp && resp.id_vehiculo) ? String(resp.id_vehiculo) : '';
+            if (id && $('#filtroVehiculo option[value="' + id + '"]').length) {
+                $('#filtroVehiculo').val(id);
+            } else {
+                $('#filtroVehiculo').val(opciones.first().val());
+            }
+            cargarHistorialVehiculo();
+        },
+        error: function () {
+            $('#filtroVehiculo').val(opciones.first().val());
+            cargarHistorialVehiculo();
+        }
+    });
+}
+
+function cargarHistorialVehiculo() {
+    idVehSel = parseInt($('#filtroVehiculo').val()) || 0;
+    placaSel = $('#filtroVehiculo option:selected').data('placa') || '';
+
+    if (!idVehSel) {
+        tabla.clear().draw();
+        toggleBotones(false);
+        return;
+    }
+
+    $.ajax({
+        url: 'acciones_gas.php',
+        type: 'POST',
+        data: { accion: 'obtenerHistorialGas', id_vehiculo: idVehSel },
         dataType: 'json',
         success: function (data) {
-            if (!Array.isArray(data)) return;
-            datosGas = data;
+            if (!Array.isArray(data)) data = [];
             tabla.clear();
 
-            // Registro más reciente (mayor id) por vehículo
-            var latestIdPorVehiculo = {};
-            data.forEach(function (r) {
-                var vid = String(r.id_vehiculo);
-                if (!latestIdPorVehiculo[vid] || parseInt(r.id) > parseInt(latestIdPorVehiculo[vid].id)) {
-                    latestIdPorVehiculo[vid] = r;
-                }
-            });
-
-            // IDs que muestran botón: son el más reciente de su vehículo Y el dueño es el usuario actual
+            // La carga más reciente (mayor id) muestra el botón de reposición si es del usuario actual
             var currentUserId = getCookie('id_usuario') || getCookie('id_usuarioL') || '';
-            var mostrarBoton = new Set();
-            Object.values(latestIdPorVehiculo).forEach(function (r) {
-                if (String(r.id_usuario) === String(currentUserId)) {
-                    mostrarBoton.add(String(r.id));
-                }
+            var latest = null;
+            data.forEach(function (r) {
+                if (!latest || parseInt(r.id) > parseInt(latest.id)) latest = r;
             });
-
-            var vehiculos = {}, usuarios = {};
+            saldoSel = latest ? (parseFloat(latest.saldo) || 0) : 0;
 
             data.forEach(function (r) {
-                var saldo    = parseFloat(r.saldo) || 0;
-                var kmCons   = parseInt(r.km_consumidos) || 0;
-                var usuario  = r.nombre_usuario || r.usuario || '—';
-                var placa    = r.placa || r.Vehiculo;
-
-                vehiculos[placa]  = r.Vehiculo;
-                usuarios[usuario] = usuario;
+                var saldo   = parseFloat(r.saldo) || 0;
+                var kmCons  = parseInt(r.km_consumidos) || 0;
+                var usuario = r.nombre_usuario || r.usuario || '—';
 
                 var badgeSaldo = saldo <= 0
                     ? '<span class="badge bg-danger">$' + saldo.toFixed(2) + '</span>'
@@ -199,9 +227,11 @@ function cargarHistorial() {
                     ? '<span class="text-primary fw-bold">' + kmCons.toLocaleString() + ' km</span>'
                     : '<span class="text-muted">—</span>';
 
-                var btnRepos = mostrarBoton.has(String(r.id))
+                var esUltimoPropio = latest && String(r.id) === String(latest.id)
+                    && String(r.id_usuario) === String(currentUserId);
+                var btnRepos = esUltimoPropio
                     ? '<button class="btn btn-outline-primary btn-sm" '
-                        + 'onclick="solicitarReposicion(' + r.id_vehiculo + ',' + saldo.toFixed(2) + ',\'' + escHtml(placa) + '\')" '
+                        + 'onclick="solicitarReposicion(' + r.id_vehiculo + ',' + saldo.toFixed(2) + ',\'' + escHtml(placaSel) + '\')" '
                         + 'title="Solicitar reposición de crédito">'
                         + '<i class="fas fa-redo me-1"></i>Renovar</button>'
                     : '';
@@ -221,20 +251,7 @@ function cargarHistorial() {
             });
 
             tabla.draw(false);
-
-            // Poblar filtros
-            var selV = $('#filtroVehiculo'), selU = $('#filtroUsuario');
-            var currentV = selV.val(), currentU = selU.val();
-            selV.empty().append('<option value="">Todos los vehículos</option>');
-            selU.empty().append('<option value="">Todos los usuarios</option>');
-            Object.entries(vehiculos).forEach(function([placa, label]) {
-                selV.append('<option value="' + escHtml(placa) + '">' + escHtml(label) + '</option>');
-            });
-            Object.keys(usuarios).sort().forEach(function(u) {
-                selU.append('<option value="' + escHtml(u) + '">' + escHtml(u) + '</option>');
-            });
-            if (currentV) selV.val(currentV);
-            if (currentU) selU.val(currentU);
+            toggleBotones(data.length > 0);
         },
         error: function () {
             Swal.fire({ icon: 'error', title: 'Error', text: 'No se pudo cargar el historial.' });
@@ -242,9 +259,8 @@ function cargarHistorial() {
     });
 }
 
-function limpiarFiltros() {
-    $('#filtroVehiculo, #filtroUsuario').val('');
-    tabla.draw();
+function toggleBotones(activo) {
+    $('#btnDescargar, #btnReposicion').prop('disabled', !activo);
 }
 
 function solicitarReposicion(id_vehiculo, saldo, placa) {
@@ -279,12 +295,11 @@ function solicitarReposicion(id_vehiculo, saldo, placa) {
     });
 }
 
-function solicitarReposicionGeneral() {
-    // Obtiene el vehículo con menor saldo del historial del usuario actual
-    var noEmp = getCookie('noEmpleado') || '';
+function solicitarReposicionVehiculo() {
+    if (!idVehSel) return;
     Swal.fire({
-        title: 'Solicitar reposición de crédito',
-        html: 'Se notificará al encargado que necesitas reposición de crédito de gasolina.',
+        title: '¿Solicitar reposición?',
+        html: 'Se enviará un correo al encargado solicitando crédito de gasolina para <strong>' + escHtml(placaSel) + '</strong>.<br>Saldo actual: <strong>$' + saldoSel.toFixed(2) + '</strong>',
         icon: 'question',
         showCancelButton: true,
         confirmButtonText: '<i class="fas fa-paper-plane me-1"></i> Enviar solicitud',
@@ -296,7 +311,7 @@ function solicitarReposicionGeneral() {
             url: 'acciones_gas.php',
             method: 'POST',
             dataType: 'json',
-            data: { accion: 'solicitarReposicionGas', id_vehiculo: 0, saldo: 0 },
+            data: { accion: 'solicitarReposicionGas', id_vehiculo: idVehSel, saldo: saldoSel },
             success: function (resp) {
                 Swal.fire({
                     icon: resp.status === 'success' ? 'success' : 'error',
@@ -314,10 +329,12 @@ function solicitarReposicionGeneral() {
 }
 
 function descargarTabla() {
+    if (!idVehSel) return;
     var wb = XLSX.utils.book_new();
     var ws = XLSX.utils.table_to_sheet(document.getElementById('tablaGas'));
     XLSX.utils.book_append_sheet(wb, ws, 'Gasolina');
-    XLSX.writeFile(wb, 'Historial_Gasolina.xlsx');
+    var placa = placaSel ? String(placaSel).replace(/[^A-Za-z0-9_-]/g, '') : ('veh' + idVehSel);
+    XLSX.writeFile(wb, 'Gasolina_' + placa + '.xlsx');
 }
 
 function escHtml(str) {

--- a/includes/api_bootstrap.php
+++ b/includes/api_bootstrap.php
@@ -4,6 +4,14 @@ header('Content-Type: application/json');
 mysqli_set_charset($conn, "utf8mb4");
 date_default_timezone_set('America/Mexico_City');
 
+// El login (loginMaster/messbook) a veces deja $_COOKIE['id_usuario'] vacío aunque sí
+// puebla id_usuarioL (el id de usuario de CV confiable). Se normaliza aquí, una sola
+// vez, para que TODO el código que lee $_COOKIE['id_usuario'] use el id correcto —
+// sin tener que parchear cada módulo (gas, kilometraje, siniestros/consultarInventario, etc.).
+if (!empty($_COOKIE['id_usuarioL']) && intval($_COOKIE['id_usuarioL']) > 0) {
+    $_COOKIE['id_usuario'] = $_COOKIE['id_usuarioL'];
+}
+
 $tieneVehiculo = false;
 if (!empty($_COOKIE['noEmpleadoL'])) {
     $connCV = new mysqli("localhost", "mess_incidencias", "Pipmytrade123", "mess_control_vehicular");

--- a/js/global/vehiculos.js
+++ b/js/global/vehiculos.js
@@ -39,11 +39,15 @@ function verPlaca(selectVehiculo, inputKm, saldo) {
             dataType: 'json',
             data: { accion: 'tomaKm', IDvehiculoAsignado: IDvehiculoAsignado },
             success: function (Registros) {
-                if (Registros && Registros[0] && Registros[0].kmMax !== undefined) {
-                    $('#' + inputKm).val(Registros[0].kmMax);
-                    $('#gasActual').val(Registros[0].gasolina_actual);
-                    $('#monto').val(Registros[0].saldo);
-                }
+                var r = (Registros && Registros[0]) ? Registros[0] : {};
+                // km y gasolina se prellenan si hay actividad previa; si no, vacío
+                // (captura manual). Nunca dejar el literal "null" en el input.
+                $('#' + inputKm).val(r.kmMax != null ? r.kmMax : '');
+                $('#gasActual').val(r.gasolina_actual != null ? r.gasolina_actual : '');
+                // Monto = saldo que arrastra la carga anterior; si no hay saldo previo
+                // o quedó en 0, la tarjeta arranca con el crédito de 4000.
+                var saldoPrev = parseFloat(r.saldo);
+                $('#monto').val((isNaN(saldoPrev) || saldoPrev <= 0) ? 4000 : saldoPrev);
             }
         });
     }

--- a/logout.php
+++ b/logout.php
@@ -1,43 +1,24 @@
+<!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="Content-type" content="text/html; charset=utf-8">
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=no">
 	<title>MESS</title>
-	<link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="http://www.datatables.net/rss.xml">
-	<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.13.1/css/jquery.dataTables.min.css">
-	<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/buttons/2.3.2/css/buttons.dataTables.min.css">
-
-	<script type="text/javascript" language="javascript" src="https://code.jquery.com/jquery-3.5.1.js"></script>
-	<script type="text/javascript" language="javascript" src="https://cdn.datatables.net/1.13.1/js/jquery.dataTables.min.js"></script>
-	<script type="text/javascript" language="javascript" src="https://cdn.datatables.net/buttons/2.3.2/js/dataTables.buttons.min.js"></script>
-	<script type="text/javascript" language="javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js"></script>
-	<script type="text/javascript" language="javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/pdfmake.min.js"></script>
-	<script type="text/javascript" language="javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>
-	<script type="text/javascript" language="javascript" src="https://cdn.datatables.net/buttons/2.3.2/js/buttons.html5.min.js"></script>
-	<script type="text/javascript" language="javascript" src="https://cdn.datatables.net/buttons/2.3.2/js/buttons.print.min.js"></script>
-	<script type="text/javascript" class="init">
-	
-		$(document).ready(function() {
-			//document.cookie = "antiguedad='.$antiguedad.';expires=" + new Date(Date.now() + 9600000).toUTCString() + ";SameSite=Lax;";
-			document.cookie = "antiguedad =00; expires=Thu, 01 Jan 1970 00:00:00 UTC";
-			document.cookie = "diasD =00; expires=Thu, 01 Jan 1970 00:00:00 UTC";
-			document.cookie = "noEmpleado =00; expires=Thu, 01 Jan 1970 00:00:00 UTC";
-			document.cookie = "nombredelusuario =00; expires=Thu, 01 Jan 1970 00:00:00 UTC";
-			document.cookie = "rol =00; expires=Thu, 01 Jan 1970 00:00:00 UTC";
-
-			let cookieSesion = getCookie("SesionLogin");
-					//alert("Cerrando sesi贸n..." + cookieSesion);
-			if (cookieSesion === "LoginMaster") {
-				document.cookie = "SesionLogin=00; expires=Thu, 01 Jan 1970 00:00:00 UTC";
-				window.location.assign("../loginMaster/inicio");
-			} else {
-				window.location.assign("../loginMaster/inicio");
-			}
-		});
-
-		//Funcion para leer cookies
+	<script>
+		// Cierre de sesión: borra las cookies y redirige. Sin jQuery ni getCookie
+		// (antes fallaba con ReferenceError y dejaba la pantalla en blanco).
+		(function () {
+			var kill = "=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/";
+			[
+				"antiguedad", "diasD", "noEmpleado", "nombredelusuario",
+				"nombredelusuarioL", "rol", "SesionLogin", "id_usuario",
+				"id_usuarioL", "navSesion", "gps"
+			].forEach(function (c) {
+				document.cookie = c + kill;
+			});
+			window.location.replace("../loginMaster/inicio");
+		})();
 	</script>
-
 </head>
-<body>
-</body>
+<body></body>
+</html>


### PR DESCRIPTION
Carga de gasolina:
- El monto arranca en 4000 cuando el vehículo no tiene saldo previo (antes quedaba vacío y no se podía capturar). Sigue readonly. (vehiculos.js)
- El saldo se recalcula en tiempo real al teclear el pago (oninput). (encabezado.php)
- tomaKm ya no falla para vehículos sin historial de actividad/gasolina: subconsultas escalares en vez de INNER JOIN. (acciones_kilometraje.php)

Historial de gasolina (ahora es por-vehículo, una tarjeta por vehículo):
- El select muestra solo los vehículos asignados del usuario; todos si es super usuario (registrarMantenimiento='TODAS'), reutilizando consultarInventario.
- La tabla y la descarga XLSX son por vehículo (Gasolina_<PLACA>.xlsx); precarga el vehículo de más km recorridos.
- Backend: obtenerHistorialGas filtra por id_vehiculo con salvaguarda anti-IDOR y nueva acción vehiculoPrincipalGas. (acciones_gas.php, historial_gasolina.php)

Fixes:
- CargarVehiculos resuelve el id de usuario de forma robusta. (acciones_kilometraje.php)
- Normalización central de $_COOKIE['id_usuario'] desde id_usuarioL: el login a veces dejaba id_usuario vacío y no cargaban los vehículos. (includes/api_bootstrap.php)
- Logout dejaba pantalla blanca por getCookie indefinida; reescrito sin jQuery, limpia cookies y redirige. (logout.php)
- Checklist de check-in: al borrar una foto, el apartado ya no queda marcado en verde como completo. (checkVehiculo.php)