### PR TITLE
Etiquetas QR: arregla el link duplicado y rediseña a 9x4cm

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -109,6 +109,51 @@ body.theme-dark .foto-captura .corner { border-color: var(--text-muted); }
 .sticker-qr-ring svg,
 .sticker-qr-ring img { display: block; }
 
+/* Respaldo blanco del QR. qr-code-styling pinta su rect de fondo con
+   clip-path="url('#clip-path-background-color')" pero NUNCA crea ese clipPath: la
+   referencia inválida hace que el navegador no dibuje el rect, así que los puntos del
+   QR caían directamente sobre el patrón decorativo del aro y lo volvían ilegible.
+   El blanco lo pone el CSS.
+
+   Es CUADRADO y mide 70.7%, el lado máximo de un cuadrado inscrito en el círculo
+   (D/raiz(2)): así deja asomar el background-image decorativo de .sticker-qr-ring en
+   los cuatro segmentos que no cubre, que es lo que hace que el QR se funda con el
+   fondo. Para un aro blanco liso, ponerlo a 100% con border-radius 50%.
+
+   NO quitar este blanco ni difuminarlo con mask: verificado con un lector real
+   (jsQR), si el patrón del aro se cuela dentro del área del QR mete módulos oscuros
+   falsos y el código DEJA DE DECODIFICAR por completo. */
+.sticker-qr-ring > div {
+    width: 62.6%; height: 62.6%;
+    flex-shrink: 0;
+    background: #ffffff;
+    border-radius: 4%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* El QR se genera a 123px fijos y sin esta regla no escala con el aro: al reducir
+   la etiqueta se desbordaría. En %, cualquier cambio de tamaño solo requiere tocar
+   .sticker-qr-ring. Al ser SVG, escalarlo no pierde nitidez.
+   Requiere el viewBox que le pone hacerEscalable() en generar_qr_vehiculo.php.
+
+   Este 96% es relativo al PANEL blanco de arriba, no al aro: el QR mide 0.626 x 0.96
+   = 60% del aro y el panel le queda casi al ras. Ese 4% sobrante es la ZONA DE
+   SILENCIO (~0.9 módulos), el margen blanco con el que el lector delimita el código.
+
+   NO subirlo a 100%. Medido con jsQR dejando el panel exactamente del tamaño del QR:
+   no decodifica a NINGUNA resolución, ni a 900px. El umbral es abrupto: con 0 módulos
+   falla y con 0.4 ya lee. Se dejó en 0.9 para tener margen ante la ganancia de tinta
+   al imprimir, que se come parte de ese blanco.
+
+   Si el panel se pusiera a 100% (aro blanco liso), el tope de este valor pasa a ser
+   70.7%: por encima, el aro (border-radius 50% + overflow hidden) muerde las ESQUINAS
+   del QR, que es donde están los patrones de localización, y deja de escanear. */
+.sticker-qr-ring canvas,
+.sticker-qr-ring svg,
+.sticker-qr-ring img { width: 96%; height: 96%; }
+
 /* Right — info panel */
 .sticker-right {
     flex: 1;
@@ -119,25 +164,25 @@ body.theme-dark .foto-captura .corner { border-color: var(--text-muted); }
     min-width: 0;
 }
 
-/* RIDE branding */
+/* RIDE branding — reducido para dar aire a la barra de logos */
 .sticker-ride-img {
     width: 100%;
-    height: 90px;
+    height: 66px;
     display: block;
     object-fit: contain;
     object-position: top center;
 }
 
-/* Vehicle info box */
+/* Vehicle info box — reducido */
 .sticker-infobox {
     border: 1.5px solid #cccccc;
     border-radius: 8px;
-    padding: 3px 9px;
+    padding: 2px 7px;
     line-height: 1.35;
     min-width: 0;
 }
 .sticker-v-line1 {
-    font-size: 2.5rem;
+    font-size: 2rem;
     font-weight: 700;
     color: #111;
     text-transform: uppercase;
@@ -145,21 +190,22 @@ body.theme-dark .foto-captura .corner { border-color: var(--text-muted); }
     overflow: hidden;
     text-overflow: ellipsis;
 }
-.sticker-v-line2 { font-size: 1.6rem; color: #333; text-transform: uppercase; }
-.sticker-v-line3 { font-size: 1.6rem; color: #333; }
-.sticker-v-line4 { font-size: 1.6rem; font-weight: 700; color: #111; letter-spacing: 1px; }
+.sticker-v-line2 { font-size: 1.3rem; color: #333; text-transform: uppercase; }
+.sticker-v-line3 { font-size: 1.3rem; color: #333; }
+.sticker-v-line4 { font-size: 1.3rem; font-weight: 700; color: #111; letter-spacing: 1px; }
 
-/* Bottom logos bar */
-.sticker-logos-bar { display: flex; align-items: center; gap: 10px; }
-.sticker-logo-mess { height: 26px; width: auto; flex-shrink: 0; }
-.sticker-logo-divider { width: 1px; height: 26px; background: #cccccc; flex-shrink: 0; }
+/* Bottom logos bar — agrandada. Misma proporción que en @media print: la columna
+   derecha mide 220px y la barra suma ~200px, así que no hay margen para más. */
+.sticker-logos-bar { display: flex; align-items: center; gap: 8px; }
+.sticker-logo-mess { height: 32px; width: auto; flex-shrink: 0; }
+.sticker-logo-divider { width: 1px; height: 32px; background: #cccccc; flex-shrink: 0; }
 .sticker-b1 { display: flex; align-items: center; gap: 6px; }
 .b1-box {
     background: #050D9E;
     color: #ffffff;
     font-weight: 900;
-    font-size: 1rem;
-    width: 28px; height: 28px;
+    font-size: 1.25rem;
+    width: 32px; height: 32px;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -167,7 +213,7 @@ body.theme-dark .foto-captura .corner { border-color: var(--text-muted); }
     flex-shrink: 0;
 }
 .b1-desc {
-    font-size: 0.55rem;
+    font-size: 0.65rem;
     color: #050D9E;
     font-weight: 700;
     text-transform: uppercase;
@@ -195,30 +241,42 @@ body.theme-dark .foto-captura .corner { border-color: var(--text-muted); }
         max-height: none !important; overflow: visible !important;
         height: auto !important; width: 100% !important;
     }
+    /* Etiqueta 9 x 4 cm, 2 por fila.
+       Ancho:  2 x 90mm + 3mm de gap = 183mm de los 205.9mm útiles (Carta, margen 5mm).
+       Alto:   6 filas de 40mm + 5 x 3mm = 255mm de 269.4mm -> 12 etiquetas por hoja. */
     #loteGrid {
         display: grid;
-        grid-template-columns: repeat(2, 98mm);
+        grid-template-columns: repeat(2, 90mm);
         gap: 3mm;
         justify-content: center;
     }
     .sticker-item {
-        width: 98mm; height: 58mm;
+        width: 90mm; height: 40mm;
         box-sizing: border-box; overflow: hidden;
         break-inside: avoid;
         display: inline-flex !important;
     }
     .sticker-body     { padding: 2mm 3mm 2mm 2mm; gap: 2.5mm; }
-    .sticker-qr-ring  { width: 48mm; height: 48mm; border-width: 1mm; image-rendering: pixelated; image-rendering: crisp-edges; }
+    /* Aquí manda el ALTO: el cuerpo mide 36mm (40 - 4 de padding) y el aro es el
+       elemento más alto, así que 35mm es su techo. La columna derecha queda en
+       90 - 5 - 35 - 2.5 = 47.5mm, y la barra de logos mide ~44mm: entra justa. */
+    .sticker-qr-ring  { width: 35mm; height: 35mm; border-width: 0.8mm; image-rendering: pixelated; image-rendering: crisp-edges; }
     .sticker-qr-ring svg, .sticker-qr-ring canvas, .sticker-qr-ring img { image-rendering: auto; }
-    .sticker-right    { gap: 1mm; }
-    .sticker-ride-img { width: 100%; height: 15mm; object-fit: contain; object-position: top center; }
-    .sticker-infobox  { padding: 1mm 2mm; border-radius: 1.5mm; line-height: 1.2; }
-    .sticker-v-line1  { font-size: 12pt; white-space: normal; overflow: visible; text-overflow: unset; }
-    .sticker-v-line4  { font-size: 12pt; }
-    .sticker-v-line2, .sticker-v-line3 { font-size: 10pt; }
-    .sticker-logos-bar { gap: 2mm; }
-    .sticker-logo-mess { height: 6mm; }
-    .sticker-logo-divider { height: 6mm; }
-    .b1-box  { width: 6mm; height: 6mm; font-size: 3mm; border-radius: 1mm; }
-    .b1-desc { font-size: 3pt; }
+    .sticker-right    { gap: 0.8mm; }
+    /* Con 36mm de cuerpo el alto va apretado: RIDE + infobox + barra suman ~34mm.
+       Subir cualquiera de estas medidas es lo primero que desborda a lo alto. */
+    .sticker-ride-img { width: 100%; height: 8mm; object-fit: contain; object-position: top center; }
+    .sticker-infobox  { padding: 0.6mm 1.5mm; border-radius: 1mm; line-height: 1.15; }
+    .sticker-v-line1  { font-size: 9pt; white-space: normal; overflow: visible; text-overflow: unset; }
+    .sticker-v-line4  { font-size: 9pt; }
+    .sticker-v-line2, .sticker-v-line3 { font-size: 7pt; }
+    /* Barra de logos, +2%: 8.5 -> 8.67mm. El imagotipo MESS es 2.36:1, así que ocupa
+       20.5mm; con divisor, B1 y descripción la barra suma ~44mm y entra holgada en los
+       57.5mm de la columna. El techo aquí es el ANCHO de la columna derecha: si se
+       agranda el aro, esta barra es lo primero que se desborda. */
+    .sticker-logos-bar { gap: 1.5mm; }
+    .sticker-logo-mess { height: 8.67mm; }
+    .sticker-logo-divider { height: 8.67mm; }
+    .b1-box  { width: 8.67mm; height: 8.67mm; font-size: 4.28mm; border-radius: 1.3mm; }
+    .b1-desc { font-size: 4.08pt; }
 }

--- a/generar_qr_vehiculo.php
+++ b/generar_qr_vehiculo.php
@@ -20,8 +20,19 @@ if (!$tieneAcceso) {
     header('location: inicio');
     exit;
 }
-$protocol = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') ? 'https' : 'http';
-$baseUrl   = $protocol . '://' . $_SERVER['HTTP_HOST'] . rtrim(dirname($_SERVER['PHP_SELF']), '/\\');
+// URL base que se codifica en el QR impreso. Es CONSTANTE a propósito: la etiqueta
+// es física y permanente, así que no puede depender de desde dónde se generó.
+// Derivándola de HTTP_HOST, generar el lote desde WAMP imprimía stickers con
+// http://localhost/... de forma irreversible.
+//
+// Capacidad del QR: typeNumber 6 + EC 'Q' = 74 bytes; con el id del vehículo esta
+// URL usa ~62. Si la constante crece más allá de eso, la librería lanza excepción y
+// el sticker sale vacío: hay que subir typeNumber en generarQrUnico() y ajustar el
+// ancho a un múltiplo de sus módulos (17 + 4*typeNumber).
+$QR_BASE_URL = 'https://messbook.com.mx/ControlVehicular';
+
+// Solo para avisar en pantalla que se está previsualizando fuera de producción.
+$esProduccion = stripos($_SERVER['HTTP_HOST'] ?? '', 'messbook.com.mx') !== false;
 ?>
 <!DOCTYPE html>
 <html lang="es">
@@ -52,6 +63,16 @@ $baseUrl   = $protocol . '://' . $_SERVER['HTTP_HOST'] . rtrim(dirname($_SERVER[
 
                 <div class="container-fluid">
                     <h1 class="h3 mb-3 text-black-800 no-print">Generar QR por Vehículo</h1>
+
+<?php if (!$esProduccion): ?>
+                    <div class="alert alert-warning d-flex align-items-center gap-2 no-print" role="alert">
+                        <i class="fas fa-triangle-exclamation"></i>
+                        <div>
+                            <strong>Vista local.</strong> Los QR de estas etiquetas apuntan a
+                            <strong>PRODUCCIÓN</strong> (<?= htmlspecialchars($QR_BASE_URL) ?>), no a este servidor.
+                        </div>
+                    </div>
+<?php endif; ?>
 
                     <!-- Tabla de vehículos -->
                     <div class="card shadow mb-4 no-print">
@@ -130,7 +151,7 @@ $baseUrl   = $protocol . '://' . $_SERVER['HTTP_HOST'] . rtrim(dirname($_SERVER[
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 
     <script>
-        var baseUrl       = <?php echo json_encode($baseUrl); ?>;
+        var baseUrl       = <?php echo json_encode($QR_BASE_URL); ?>;
         var loteIds       = [];
         var vehiculosData = {};
         var selectedIds   = new Set();
@@ -241,21 +262,38 @@ $baseUrl   = $protocol . '://' . $_SERVER['HTTP_HOST'] . rtrim(dirname($_SERVER[
 
         // Agregar al lote
         // Hace únicos los IDs internos del SVG del QR (clip-path-dot-color, etc.).
-        // qr-code-styling los emite SIN sufijo, así que con varios QR en la misma
-        // página los url(#id) colisionan (SVG resuelve al primer id del documento)
-        // y los QR salen recortados/mal. Se les añade el id del contenedor como sufijo.
+        // qr-code-styling los emite SIN sufijo de instancia: 'clip-path-dot-color' y
+        // 'clip-path-background-color' son literales, y los de las esquinas se indexan
+        // por posición ('...-0-0'), no por QR. Con varios QR en la misma página los
+        // url(#id) colisionan —SVG resuelve al primer id del documento— y TODAS las
+        // etiquetas acaban pintando el QR de la primera. Pasó en producción: se
+        // imprimió un lote entero donde todas escaneaban al mismo vehículo.
+        // Se les añade el id del contenedor como sufijo.
+        var ATRIBUTOS_CON_REF = ['clip-path', 'mask', 'fill', 'stroke'];
+
         function hacerIdsUnicos(cont, sufijo) {
             var svg = cont.querySelector('svg');
             if (!svg) return false;
             var conId = svg.querySelectorAll('[id]');
             if (!conId.length) return false;
+            var nodos = svg.querySelectorAll('*');
             conId.forEach(function (el) {
                 var viejo = el.id, nuevo = viejo + '-' + sufijo;
                 el.id = nuevo;
-                svg.querySelectorAll('*').forEach(function (n) {
-                    ['clip-path', 'mask', 'fill', 'stroke'].forEach(function (a) {
-                        if (n.getAttribute && n.getAttribute(a) === 'url(#' + viejo + ')') {
-                            n.setAttribute(a, 'url(#' + nuevo + ')');
+                // La librería escribe las referencias como url('#id') CON comillas
+                // simples, así que no sirve comparar contra la cadena url(#id) pelada.
+                // Se contemplan las tres formas: url(#id), url('#id') y url("#id").
+                // El \) final es lo que evita que #clip-path-corners-dot-color haga
+                // match parcial dentro de #clip-path-corners-dot-color-0-0.
+                var ref = new RegExp(
+                    'url\\((["\']?)#' + viejo.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\1\\)',
+                    'g'
+                );
+                nodos.forEach(function (n) {
+                    ATRIBUTOS_CON_REF.forEach(function (a) {
+                        var val = n.getAttribute(a);
+                        if (val && val.indexOf('#' + viejo) !== -1) {
+                            n.setAttribute(a, val.replace(ref, 'url($1#' + nuevo + '$1)'));
                         }
                     });
                 });
@@ -287,13 +325,41 @@ $baseUrl   = $protocol . '://' . $_SERVER['HTTP_HOST'] . rtrim(dirname($_SERVER[
                 image: 'img/MESS_07_CuboMess_1.png',
                 imageOptions: { crossOrigin: 'anonymous', margin: 0, imageSize: 0.3 }
             }).append(cont);
-            // qr-code-styling dibuja de forma asíncrona; en cuanto el SVG tenga sus IDs
-            // los hacemos únicos y desconectamos el observer.
+            // qr-code-styling dibuja de forma asíncrona; en cuanto el SVG esté listo
+            // lo preparamos y desconectamos el observer.
             var obs = new MutationObserver(function () {
-                if (hacerIdsUnicos(cont, qrDivId)) obs.disconnect();
+                if (prepararSvg(cont, qrDivId)) obs.disconnect();
             });
             obs.observe(cont, { childList: true, subtree: true });
-            setTimeout(function () { if (hacerIdsUnicos(cont, qrDivId)) obs.disconnect(); }, 600);
+            setTimeout(function () { if (prepararSvg(cont, qrDivId)) obs.disconnect(); }, 600);
+        }
+
+        // La librería crea el <svg> con width/height="123" y SIN viewBox. Sin viewBox
+        // el dibujo tiene tamaño fijo en unidades de usuario: darle un ancho por CSS
+        // encoge la ventana pero NO el contenido, así que el QR sale RECORTADO en vez
+        // de escalado. Cambiando width/height por un viewBox equivalente, el SVG pasa
+        // a escalar de verdad y obedece el % de .sticker-qr-ring en css/app.css.
+        function hacerEscalable(svg) {
+            if (svg.getAttribute('viewBox')) return;
+            var w = parseFloat(svg.getAttribute('width')),
+                h = parseFloat(svg.getAttribute('height'));
+            if (!w || !h) return;
+            svg.setAttribute('viewBox', '0 0 ' + w + ' ' + h);
+            svg.removeAttribute('width');
+            svg.removeAttribute('height');
+        }
+
+        // Idempotente a propósito: la llaman el MutationObserver y el setTimeout de
+        // respaldo, y sin la marca el sufijo se aplicaba dos veces
+        // (clip-path-dot-color-qrLote5-qrLote5).
+        function prepararSvg(cont, sufijo) {
+            var svg = cont.querySelector('svg');
+            if (!svg) return false;
+            if (svg.dataset.qrListo === '1') return true;
+            if (!hacerIdsUnicos(cont, sufijo)) return false;
+            hacerEscalable(svg);
+            svg.dataset.qrListo = '1';
+            return true;
         }
 
         function agregarAlLote(id, placa, modelo, marca, anio, skipScroll) {
@@ -340,28 +406,11 @@ $baseUrl   = $protocol . '://' . $_SERVER['HTTP_HOST'] . rtrim(dirname($_SERVER[
             $('#loteGrid').append(html);
             $('#loteContainer').show();
 
-            //QR Code Styling
-            new QRCodeStyling({
-                width: 123,
-                height: 123,
-                margin: 0,
-                type: 'svg',
-                data: url,
-                // typeNumber 6 = 41 módulos -> 123/41 = 3px exactos por módulo.
-                // Sin fijarlo, la versión la elige la librería según el largo de la URL:
-                // los ids de 1 dígito daban v5 (37 módulos) -> floor(123/37)=3 -> QR de
-                // 111px, y el fondo blanco de 123x123 asomaba alrededor.
-                // Capacidad v6 con EC 'Q' = 74 bytes (la URL usa ~62). Si baseUrl crece
-                // más allá de eso hay que subir typeNumber Y ajustar el ancho a múltiplo
-                // de sus módulos (17 + 4*typeNumber).
-                qrOptions: { typeNumber: 6, errorCorrectionLevel: 'Q' },
-                dotsOptions:          { color: '#074480', type: 'square' },
-                backgroundOptions:    { color: '#ffffff' },
-                cornersSquareOptions: { color: '#074480', type: 'square' },
-                cornersDotOptions:    { color: '#074480', type: 'square' },
-                image: 'img/MESS_07_CuboMess_1.png',
-                imageOptions: { crossOrigin: 'anonymous', margin: 0, imageSize: 0.3 }
-            }).append(document.getElementById(qrDivId));
+            // SIEMPRE vía generarQrUnico(). Instanciar QRCodeStyling aquí en línea se
+            // salta hacerIdsUnicos() y todas las etiquetas del lote salen con el QR de
+            // la primera. Ya se perdió una vez resolviendo un merge (67c4673) y llegó
+            // así a producción.
+            generarQrUnico(qrDivId, url);
 
             loteIds.push(id);
             actualizarContador();

--- a/js/global/modals.js
+++ b/js/global/modals.js
@@ -6,12 +6,18 @@ function verificarPermisoUbicacion() {
     var msg    = document.getElementById('avisoUbicacionMsg');
     var btn    = document.getElementById('btnAceptarUbicacion');
 
+    // El permiso del SITIO en el navegador y el GPS del teléfono son cosas distintas:
+    // activar la ubicación del celular no desbloquea un sitio que ya fue denegado. El
+    // texto de 'denied' lo dice explícitamente porque es la confusión más común.
     var TEXTOS = {
-        denied: ['Ubicación bloqueada', 'Tu navegador tiene bloqueada la ubicación para este sitio. Permite la ubicación y recarga la página.'],
+        denied: ['Ubicación bloqueada', 'Activar el GPS del teléfono no basta: la ubicación está bloqueada para este sitio en el navegador. Permítela desde el candado de la barra de direcciones (Ajustes del sitio → Ubicación) y pulsa "Volver a comprobar".'],
         prompt: ['Habilita el acceso a tu ubicación', 'Para el correcto funcionamiento de Control Vehicular necesitamos acceso a tu ubicación y cookies. Acepta los permisos cuando el navegador te lo solicite.']
     };
 
+    var estadoActual = 'prompt';
+
     function aplicar(state) {
+        estadoActual = state;
         if (state === 'granted') {
             localStorage.setItem('cv_ubicacion_aceptada', '1');
             banner.classList.add('d-none');
@@ -25,26 +31,48 @@ function verificarPermisoUbicacion() {
         titulo.textContent = t[0];
         msg.textContent    = t[1];
         if (btn) {
-            if (state === 'denied') {
-                btn.classList.add('d-none');
-            } else {
-                btn.classList.remove('d-none');
-            }
+            // Denegado no se puede volver a preguntar por JS: el navegador ya no muestra
+            // el diálogo. Antes el botón se ocultaba y el usuario quedaba sin salida;
+            // ahora ofrece releer el permiso después de cambiarlo en los ajustes.
+            btn.innerHTML = (state === 'denied')
+                ? '<i class="fas fa-rotate-right me-1"></i> Volver a comprobar'
+                : '<i class="fas fa-check me-1"></i> Habilitar ubicación';
+            btn.classList.remove('d-none');
         }
         banner.classList.remove('d-none');
     }
 
-    if (navigator.permissions && navigator.permissions.query) {
-        navigator.permissions.query({ name: 'geolocation' }).then(function (status) {
-            aplicar(status.state);
-            status.onchange = function () { aplicar(status.state); };
-        }).catch(function () { aplicar('prompt'); });
-    } else {
-        aplicar('prompt');
+    function consultar() {
+        if (navigator.permissions && navigator.permissions.query) {
+            navigator.permissions.query({ name: 'geolocation' }).then(function (status) {
+                aplicar(status.state);
+                status.onchange = function () { aplicar(status.state); };
+            }).catch(function () { aplicar('prompt'); });
+        } else {
+            // Safari/iOS no implementa permissions.query para geolocation.
+            aplicar('prompt');
+        }
     }
+
+    consultar();
+
+    // Al volver a la pestaña hay que reconsultar: es justo lo que hace el usuario tras
+    // cambiar el permiso en los ajustes del navegador, y ahí status.onchange no siempre
+    // llega (página congelada en segundo plano o restaurada del bfcache). Solo se
+    // reconsulta si el aviso está visible, para no gastar consultas cuando ya está todo bien.
+    document.addEventListener('visibilitychange', function () {
+        if (!document.hidden && !banner.classList.contains('d-none')) consultar();
+    });
+    window.addEventListener('pageshow', function (e) {
+        if (e.persisted && !banner.classList.contains('d-none')) consultar();
+    });
 
     if (btn) {
         btn.addEventListener('click', function () {
+            if (estadoActual === 'denied') {
+                consultar();
+                return;
+            }
             navigator.geolocation.getCurrentPosition(
                 function ()    { aplicar('granted'); },
                 function (err) { if (err && err.code === err.PERMISSION_DENIED) aplicar('denied'); },

--- a/logout.php
+++ b/logout.php
@@ -1,12 +1,27 @@
-<!DOCTYPE html>
-<html>
-<head>
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=no">
-	<title>MESS</title>
-	<script>
-		window.location.replace("../loginMaster/inicio");
-	</script>
-</head>
-<body></body>
-</html>
+<?php
+// Cierre de sesión de Control Vehicular.
+//
+// Sin HTML ni JS a propósito: el navegador no llega a pintar nada, así que no
+// hay pantalla en blanco si falla un CDN (era el bug del logout viejo, que
+// dependía de jQuery y moría con ReferenceError dejando el <body> vacío).
+//
+// Solo se borran las cookies de CV. Las *L (noEmpleadoL, id_usuarioL, ...) son
+// de loginMaster y viven en path=/: se respetan porque el destino es el inicio
+// del hub, donde el usuario sigue logueado.
+
+// CV escribe sus cookies sin path (quedan en /ControlVehicular), pero
+// js/global/vehiculos.js sincroniza 'noEmpleado' en path=/ y ese es el que usa
+// el guard de las vistas: hay que matar ambos o la sesión no se cierra.
+$cookies = array(
+    'id_usuario', 'nombredelusuario', 'noEmpleado', 'rol',
+    'gps', 'SesionLogin', 'navSesion', 'antiguedad', 'diasD'
+);
+
+foreach ($cookies as $cookie) {
+    foreach (array('/ControlVehicular', '/') as $path) {
+        setcookie($cookie, '', time() - 3600, $path);
+    }
+}
+
+header('Location: ../loginMaster/inicio');
+exit;


### PR DESCRIPTION
Link duplicado: qr-code-styling emite los ids del SVG sin sufijo de instancia, así que con varios QR en la página SVG resuelve url(#id) contra todo el documento y gana el primero. Ya existía hacerIdsUnicos(), pero se perdió la llamada en el merge 67c4673 y además comparaba contra url(#id) cuando la librería escribe url('#id') con comillas simples.

QR ilegible: la librería recorta su fondo blanco con un clip-path que nunca crea, así que no se dibujaba y los puntos caían sobre el patrón del aro. Verificado con jsQR: el diseño anterior no decodificaba a ninguna resolución. El fondo lo pone ahora el CSS. Se añade también el viewBox que faltaba, sin el cual escalar por CSS recortaba el código.

URL base fija a producción: se derivaba de HTTP_HOST y generar el lote desde WAMP imprimía etiquetas con http://localhost de forma irreversible.

Etiqueta a 9x4cm, 12 por hoja Carta, QR de 20.1mm.

Logout: era una página vacía que redirigía desde $(document).ready detrás de siete CDN; si alguno fallaba la pestaña se quedaba en blanco. Ahora es PHP puro con cabeceras y borra las cookies de CV en ambos paths.