### PR TITLE
Junta 20/08: notificaciones, accesos, gasolina y checklist

### DIFF
--- a/acciones_gas.php
+++ b/acciones_gas.php
@@ -77,14 +77,69 @@ $fecha_registro = isset($_POST['fecha_registro']) ? $_POST['fecha_registro'] : n
 
     //FUNCION PARA REGISTRAR CARGA
     if ($accion == 'registraGas'){
-        $sqlR = "INSERT INTO carga_gasolina (`id_usuario`, `id_vehiculo`, `monto`, `pagos`, `saldo`, `km_actual`, `fecha_carga`, `fecha_registro`) 
-                VALUES ('$id_usuario', '$id_vehiculo', '$monto', '$pagos', '$saldo', '$km_actual', '$fecha_carga', now())";
-            
-        $resultR = $conn->query($sqlR);
-        if($resultR){
-            echo json_encode(array("status" => "success", "message" => "Carga de gasolina registrada correctamente."));
+        // Validación y normalización en servidor. Antes se concatenaba todo directo al
+        // INSERT y se confiaba en que MySQL acomodara los tipos: en local funciona
+        // porque sql_mode está vacío y MySQL convierte en silencio, pero con
+        // STRICT_TRANS_TABLES (lo normal en producción) el mismo INSERT falla. Como el
+        // front daba por buena cualquier respuesta HTTP 200, el usuario veía "Guardado"
+        // sin que se hubiera guardado nada.
+        $idVeh = intval($id_vehiculo);
+        $idUsr = intval($id_usuario);
+        if ($idVeh <= 0 || $idUsr <= 0) {
+            echo json_encode(["status" => "error", "message" => "Falta el vehículo o la sesión no es válida."]);
+            exit;
+        }
+
+        // km_actual es INT en la tabla: se rechaza el decimal en vez de dejar que MySQL
+        // lo redondee sin avisar (un odómetro no lleva fracciones).
+        if ($km_actual === null || $km_actual === '' || !is_numeric($km_actual)) {
+            echo json_encode(["status" => "error", "message" => "El kilometraje es obligatorio y debe ser un número."]);
+            exit;
+        }
+        if (floor((float)$km_actual) != (float)$km_actual) {
+            echo json_encode(["status" => "error", "message" => "El kilometraje debe ser un número entero, sin decimales."]);
+            exit;
+        }
+        $km = intval($km_actual);
+        if ($km < 0) {
+            echo json_encode(["status" => "error", "message" => "El kilometraje no puede ser negativo."]);
+            exit;
+        }
+
+        // fecha_carga es DATE, pero el input es datetime-local y manda "2026-08-20T12:43".
+        // Se normaliza a Y-m-d; la hora se descarta porque la columna no la guarda.
+        $fechaLimpia = null;
+        if (!empty($fecha_carga)) {
+            $ts = strtotime(str_replace('T', ' ', $fecha_carga));
+            if ($ts) $fechaLimpia = date('Y-m-d', $ts);
+        }
+        if (!$fechaLimpia) {
+            echo json_encode(["status" => "error", "message" => "La fecha de carga es obligatoria y debe tener un formato válido."]);
+            exit;
+        }
+
+        $montoNum = is_numeric($monto) ? (float)$monto : 0;
+        $pagosNum = is_numeric($pagos) ? (float)$pagos : 0;
+        $saldoNum = is_numeric($saldo) ? (float)$saldo : ($montoNum - $pagosNum);
+
+        $stmt = $conn->prepare(
+            "INSERT INTO carga_gasolina
+                (id_usuario, id_vehiculo, monto, pagos, saldo, km_actual, fecha_carga, fecha_registro)
+             VALUES (?, ?, ?, ?, ?, ?, ?, NOW())"
+        );
+        if (!$stmt) {
+            echo json_encode(["status" => "error", "message" => "Error al preparar el registro: " . $conn->error]);
+            exit;
+        }
+        $stmt->bind_param("iidddis", $idUsr, $idVeh, $montoNum, $pagosNum, $saldoNum, $km, $fechaLimpia);
+        $ok = $stmt->execute();
+        $err = $stmt->error;
+        $stmt->close();
+
+        if ($ok) {
+            echo json_encode(["status" => "success", "message" => "Carga de gasolina registrada correctamente.", "saldo" => $saldoNum]);
         } else {
-            echo json_encode(array("status" => "error", "message" => "Error al registrar la carga de gasolina: " . $conn->error));
+            echo json_encode(["status" => "error", "message" => "Error al registrar la carga de gasolina: " . $err]);
         }
         exit;
     }

--- a/acciones_kilometraje.php
+++ b/acciones_kilometraje.php
@@ -268,6 +268,80 @@ if($accion == 'ActividadesPendientes'){
     exit;
 }
 
+/**
+ * Vista de gerentes: TODOS los check-in en crudo.
+ *
+ * Deliberadamente NO cruza INICIO con FINALIZACION como hace 'Actividades' más abajo.
+ * Ese cruce solo devuelve viajes cerrados y los usuarios no cierran la actividad: de
+ * 379 INICIO hay 312 FINALIZACION, así que un listado por pares esconde justo los
+ * registros que hay que auditar. Aquí sale una fila por registro, y los INICIO sin
+ * cierre posterior se marcan con abierto = 1.
+ *
+ * El acceso se valida en servidor con accesos_especiales (nunca con la cookie `rol`,
+ * que la escribe el cliente). Ver includes/api_bootstrap.php.
+ *
+ * Se usa verTodosVehiculo y no un permiso propio: ver los check-in de toda la flota
+ * implica ver toda la flota, así que separarlos permitiría dar uno sin el otro.
+ */
+if ($accion == 'consultarCheckins') {
+    if (!tieneAccesoEspecial($conn, $_COOKIE['noEmpleado'] ?? 0, 'verTodosVehiculo')) {
+        echo json_encode(['status' => 'error', 'message' => 'No tienes acceso a esta vista.']);
+        exit;
+    }
+
+    $desde = $_POST['desde'] ?? '';
+    $hasta = $_POST['hasta'] ?? '';
+    $idVeh = intval($_POST['id_vehiculo'] ?? 0);
+
+    // Por defecto los últimos 30 días: la tabla crece sin tope y traerla completa
+    // castiga al navegador del que abre la vista.
+    if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $desde)) $desde = date('Y-m-d', strtotime('-30 days'));
+    if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $hasta)) $hasta = date('Y-m-d');
+
+    $filtroVeh = $idVeh > 0 ? " AND av.id_vehiculo = ? " : "";
+
+    // El JOIN a usuarios usa MAX(id) porque usuarios.id_usuario NO es único; un LEFT
+    // JOIN directo multiplicaría las filas del listado.
+    $sql = "SELECT av.id_actividad, av.id_vehiculo, av.tipo_actividad, av.fecha_actividad,
+                   av.km_actual, av.gasolina_actual, av.coordenadas, av.foto_url,
+                   av.notas, av.ot, av.patron,
+                   inv.placa, inv.marca, inv.modelo,
+                   IFNULL(NULLIF(TRIM(CONCAT(IFNULL(rrhh.nombres,''),' ',IFNULL(rrhh.apellidos,''))),''), u.nombre) AS usuario,
+                   CASE WHEN av.tipo_actividad = 'INICIO' AND NOT EXISTS (
+                            SELECT 1 FROM actividad_vehiculo f
+                            WHERE f.id_vehiculo = av.id_vehiculo
+                              AND f.id_usuario  = av.id_usuario
+                              AND f.tipo_actividad = 'FINALIZACION'
+                              AND f.fecha_actividad > av.fecha_actividad
+                        ) THEN 1 ELSE 0 END AS abierto
+            FROM actividad_vehiculo av
+            LEFT JOIN inventario inv ON inv.id_vehiculo = av.id_vehiculo
+            LEFT JOIN usuarios u ON u.id = (
+                SELECT MAX(u2.id) FROM usuarios u2 WHERE u2.id_usuario = av.id_usuario
+            )
+            LEFT JOIN mess_rrhh.usuarios rrhh ON rrhh.noEmpleado = u.noEmpleado
+            WHERE DATE(av.fecha_actividad) BETWEEN ? AND ?
+            $filtroVeh
+            ORDER BY av.fecha_actividad DESC, av.id_actividad DESC";
+
+    $stmt = $conn->prepare($sql);
+    if (!$stmt) {
+        echo json_encode(['status' => 'error', 'message' => 'Error al preparar la consulta.']);
+        exit;
+    }
+    if ($idVeh > 0) $stmt->bind_param("ssi", $desde, $hasta, $idVeh);
+    else            $stmt->bind_param("ss", $desde, $hasta);
+    $stmt->execute();
+    $res = $stmt->get_result();
+
+    $checkins = [];
+    while ($row = $res->fetch_assoc()) $checkins[] = $row;
+    $stmt->close();
+
+    echo json_encode(['status' => 'success', 'desde' => $desde, 'hasta' => $hasta, 'checkins' => $checkins]);
+    exit;
+}
+
 if($accion == 'Actividades'){
     // Consultar las actividades del usuario actual
     /*$sql = "SELECT av.*, i.placa, i.marca, i.modelo, (select u.nombre from usuarios u where u.id_usuario = av.id_usuario) as usuario

--- a/acciones_mantenimiento.php
+++ b/acciones_mantenimiento.php
@@ -1,5 +1,6 @@
 <?php
 include 'includes/api_bootstrap.php';
+require_once __DIR__ . '/includes/enviar_notificacion.php';  // aviso al solicitante al resolver
 
 $accion = $_POST["accion"] ?? '';
 
@@ -260,20 +261,47 @@ if ($accion == "consultarMantenimientos") {
 
 //Aprobar Mantenimiento
 if ($accion == "autorizarMantenimiento") {
-    $sqlAutoriza = "UPDATE mantenimientos 
-            SET VoBo_jefe = 'AUTORIZADO', notas = '$notas', fecha_programada = '$fecha_programada', folio = '$folioOC', costo = '$costo'
-            WHERE id_mantenimiento = $id_mantenimiento";
-    $resultAutoriza = $conn->query($sqlAutoriza);
-    echo json_encode(["success" => true]);
+    $stmt = $conn->prepare("UPDATE mantenimientos
+            SET VoBo_jefe = 'AUTORIZADO', notas = ?, fecha_programada = ?, folio = ?, costo = ?
+            WHERE id_mantenimiento = ?");
+    $stmt->bind_param("ssssi", $notas, $fecha_programada, $folioOC, $costo, $id_mantenimiento);
+    $stmt->execute();
+    $actualizo = $stmt->affected_rows > 0;
+    $stmt->close();
+
+    // El correo va DESPUÉS de confirmar el UPDATE y no debe tumbar la operación: si
+    // el SMTP falla, el mantenimiento igual quedó autorizado.
+    $avisado = false;
+    if ($actualizo) {
+        try {
+            $avisado = enviarNotificacionResolucionMantenimiento($conn, $id_mantenimiento, 'AUTORIZADO');
+        } catch (Throwable $e) {
+            error_log("Fallo al notificar autorización de $id_mantenimiento: " . $e->getMessage());
+        }
+    }
+
+    echo json_encode(["success" => $actualizo, "notificado" => $avisado]);
 }
 
 //Denegar Mantenimiento
 if ($accion == "denegarMantenimiento") {
-    $sqlDenegar = "UPDATE mantenimientos 
-            SET VoBo_jefe = 'DENEGADO', notas = '$notas', fecha_programada = '$fecha_programada' 
-            WHERE id_mantenimiento = '$id_mantenimiento'";
-    $resultDenegar = $conn->query($sqlDenegar);
+    $stmt = $conn->prepare("UPDATE mantenimientos
+            SET VoBo_jefe = 'DENEGADO', notas = ?, fecha_programada = ?
+            WHERE id_mantenimiento = ?");
+    $stmt->bind_param("ssi", $notas, $fecha_programada, $id_mantenimiento);
+    $stmt->execute();
+    $actualizo = $stmt->affected_rows > 0;
+    $stmt->close();
 
-    echo json_encode(["success" => true]);
+    $avisado = false;
+    if ($actualizo) {
+        try {
+            $avisado = enviarNotificacionResolucionMantenimiento($conn, $id_mantenimiento, 'DENEGADO');
+        } catch (Throwable $e) {
+            error_log("Fallo al notificar denegación de $id_mantenimiento: " . $e->getMessage());
+        }
+    }
+
+    echo json_encode(["success" => $actualizo, "notificado" => $avisado]);
 }
 ?>

--- a/acciones_prestamos.php
+++ b/acciones_prestamos.php
@@ -1,5 +1,6 @@
 <?php
 include 'includes/api_bootstrap.php';
+require_once __DIR__ . '/includes/enviar_notificacion.php';  // aviso de nueva solicitud
 
 $accion = $_POST["accion"] ?? '';
 
@@ -36,15 +37,39 @@ $tipo_uso = $_POST["tipo_uso"] ?? null;
 $detalle_tipo_uso = $_POST["detalle_tipo_uso"] ?? null;
 $notas_jefe = $_POST["notas_jefe"] ?? null;
 $destino = $_POST["destino"] ?? null;
+
+// Guard de sesión. Si id_usuario llega vacío, las consultas de abajo lo interpolan sin
+// comillas (WHERE id_usuario = ) y revientan con error de sintaxis; el front solo
+// alcanzaba a mostrar "error" y la lista de vehículos quedaba vacía, sin pista de por qué.
+// api_bootstrap.php ya normaliza la cookie desde id_usuarioL, así que llegar aquí sin id
+// significa sesión perdida de verdad: hay que decirlo, no dejar reventar el SQL.
+if (intval($id_usuario) <= 0) {
+    echo json_encode([
+        "success" => false,
+        "error"   => "sesion_invalida",
+        "message" => "Tu sesión no tiene un usuario válido. Vuelve a iniciar sesión e inténtalo de nuevo."
+    ]);
+    exit;
+}
 /*---------------------------------------------*/
 //Registro de Prestamo
 if ($accion == "RegistrarPrestamo") {
     $sqlregistro = "INSERT INTO prestamos
                     (fecha_registro, id_usuario, fecha_inc_prestamo, fecha_fin_prestamo, estatus, motivo_us, tipo_uso, destino, id_vehiculo)
                     VALUES (NOW(), '$id_usuario', '$fecha_inc_prestamo', '$fecha_fin_prestamo', 'PENDIENTE', '$motivo', '$tipo_uso',  '$destino', '$id_vehiculo')";
-    $resultregistro = $conn->query($sqlregistro); 
+    $resultregistro = $conn->query($sqlregistro);
     if ($resultregistro) {
-        echo json_encode(["success" => true, "message" => "Préstamo registrado exitosamente."]);
+        // El aviso se manda desde aquí y no por AJAX a correoPrestamo.php: ahí el id
+        // del préstamo recién creado ya existe y se pueden incluir vehículo, fechas,
+        // destino y tipo de uso. (La llamada a correoPrestamo.php estaba comentada en
+        // prestamos.php, así que este correo llevaba tiempo sin enviarse.)
+        $avisado = false;
+        try {
+            $avisado = enviarNotificacionSolicitudPrestamo($conn, $conn->insert_id);
+        } catch (Throwable $e) {
+            error_log("Fallo al notificar solicitud de préstamo: " . $e->getMessage());
+        }
+        echo json_encode(["success" => true, "message" => "Préstamo registrado exitosamente.", "notificado" => $avisado]);
     } else {
         echo json_encode(["success" => false, "message" => "Error al registrar la solicitud: " . $conn->error]);
     }
@@ -70,6 +95,10 @@ if ($accion == "consultarPrestamos") {
         $esJefe = $stmtJefe->get_result()->num_rows > 0;
         $stmtJefe->close();
 
+        // Tercera vía: acceso especial al historial completo, para quien necesita verlo
+        // sin ser jefe de nadie (la jerarquía de arriba no lo cubre). Se valida en servidor.
+        $verTodosPrestamos = tieneAccesoEspecial($conn, $noEmpleado, 'verHistorialPrestamos');
+
         $selectFechas = $usarFechasActividad
             ? "(SELECT MAX(fecha_actividad) FROM actividad_vehiculo WHERE id_vehiculo = prest.id_vehiculo AND tipo_actividad = 'INICIO') AS fecha_inc_prestamo,
             (SELECT MAX(fecha_actividad) FROM actividad_vehiculo WHERE id_vehiculo = prest.id_vehiculo AND tipo_actividad = 'FINALIZACION') AS fecha_fin_prestamo,"
@@ -78,11 +107,13 @@ if ($accion == "consultarPrestamos") {
         $camposExtra = $esPendiente ? "" : ", prest.notas_jefe, prest.id_usuario, prest.fecha_entrega,
                         (SELECT MAX(km_actual) FROM actividad_vehiculo WHERE id_vehiculo = prest.id_vehiculo) AS km";
 
-        $propiedadCol = $esJefe
+        $propiedadCol = ($esJefe || $verTodosPrestamos)
             ? ", CASE WHEN inv.id_usuario = $id_usuario THEN 'mio' ELSE 'otro' END AS propiedad_vehiculo"
             : "";
 
-        if ($esJefe) {
+        if ($verTodosPrestamos) {
+            $whereRol = "1 = 1";
+        } elseif ($esJefe) {
             $whereRol = "(prest.id_usuario IN (SELECT id_usuario FROM usuarios WHERE jefe = $noEmpleado UNION ALL SELECT $id_usuario)
                         OR prest.id_vehiculo IN (SELECT id_vehiculo FROM inventario WHERE id_usuario = $id_usuario))";
         } else {

--- a/acciones_qr.php
+++ b/acciones_qr.php
@@ -112,9 +112,17 @@ if ($accion === 'obtenerValidacionesVehiculo') {
     foreach ($subareas as $key => $tabla) {
         $estatus = 'no_revisado'; // default si no hay registro
         if ($idChecklist > 0) {
-            // Si todos los registros de la subárea tienen buen_estado='Si' → ok; si hay al menos uno != Si → mal; si no hay registros → no_revisado
-            $sqlSub = "SELECT COUNT(*) AS total,
-                              SUM(CASE WHEN buen_estado = 'Si' THEN 1 ELSE 0 END) AS ok
+            // buen_estado guarda '1' (bien) / '0' (mal) / '' (sin responder). Antes esto
+            // comparaba contra 'Si', valor que NO EXISTE en la tabla: en las 480 filas de
+            // la BD solo hay '0', '1' y ''. Por eso el conteo de OK siempre daba 0 y el
+            // panel pintaba TODAS las subáreas en rojo, aunque estuvieran revisadas y bien.
+            // Se aceptan también 'Si'/'SI' por si algún registro viejo los trae.
+            //
+            // Las filas sin responder no cuentan como 'mal': se ignoran, y si no queda
+            // ninguna respondida la subárea es 'no_revisado'.
+            $sqlSub = "SELECT
+                          SUM(CASE WHEN TRIM(buen_estado) <> '' THEN 1 ELSE 0 END) AS respondidas,
+                          SUM(CASE WHEN buen_estado = '1' OR UPPER(buen_estado) = 'SI' THEN 1 ELSE 0 END) AS ok
                        FROM $tabla WHERE id_checklist = ?";
             $stmtSub = $conn->prepare($sqlSub);
             if ($stmtSub) {
@@ -122,11 +130,11 @@ if ($accion === 'obtenerValidacionesVehiculo') {
                 $stmtSub->execute();
                 $rowSub = $stmtSub->get_result()->fetch_assoc();
                 $stmtSub->close();
-                $total = intval($rowSub['total']);
-                $ok    = intval($rowSub['ok']);
-                if ($total === 0)        $estatus = 'no_revisado';
-                else if ($ok === $total) $estatus = 'ok';
-                else                     $estatus = 'mal';
+                $respondidas = intval($rowSub['respondidas']);
+                $ok          = intval($rowSub['ok']);
+                if ($respondidas === 0)      $estatus = 'no_revisado';
+                else if ($ok === $respondidas) $estatus = 'ok';
+                else                         $estatus = 'mal';
             }
         }
         $detalleSubareas[$key] = $estatus;
@@ -288,6 +296,26 @@ if ($accion === 'checkInQR') {
     $ultimoKM = obtenerUltimoKMVehiculo($conn, $id_vehiculo);
     if ($km_actual > 0 && $ultimoKM > 0 && $km_actual < $ultimoKM) {
         echo json_encode(['error' => "El KM ingresado ($km_actual) es menor al ultimo registrado ($ultimoKM)."]);
+        exit;
+    }
+
+    // La foto del odómetro es OBLIGATORIA en el primer registro de KM de la semana: es la
+    // única evidencia de esa lectura y sin ella el KPI de kilometraje no se puede auditar.
+    // Se recalcula aquí en vez de confiar en el flag que mandó el cliente, que es
+    // manipulable; la condición es la misma que usa 'verificarEstadoCheckin'.
+    $stmtSem = $conn->prepare("
+        SELECT 1 FROM actividad_vehiculo
+        WHERE id_vehiculo = ? AND km_actual > 0
+          AND YEARWEEK(fecha_actividad, 1) = YEARWEEK(CURDATE(), 1)
+        LIMIT 1
+    ");
+    $stmtSem->bind_param("i", $id_vehiculo);
+    $stmtSem->execute();
+    $hayKMEstaSemana = (bool) $stmtSem->get_result()->fetch_assoc();
+    $stmtSem->close();
+
+    if (!$hayKMEstaSemana && !(isset($_FILES['foto']) && $_FILES['foto']['error'] === UPLOAD_ERR_OK)) {
+        echo json_encode(['error' => 'La foto del kilometraje es obligatoria en el primer registro de la semana.']);
         exit;
     }
 

--- a/acciones_siniestro.php
+++ b/acciones_siniestro.php
@@ -233,10 +233,15 @@ if ($accion == "consultarInventarioAutoriza") {
 
 // Feed cronológico de todos los siniestros
 if ($accion == "obtenerFeedSiniestros") {
-    $rol = $_COOKIE['rol'] ?? null;
+    // Antes esto dependía de la cookie `rol`: cualquier valor distinto de '1' veía TODOS
+    // los siniestros de la empresa. Como esa cookie la escribe el cliente y no va firmada,
+    // bastaba con editarla en el navegador para saltarse el filtro. Ahora el acceso total
+    // se valida en servidor contra accesos_especiales; quien no lo tenga sigue viendo solo
+    // los siniestros de sus vehículos (propios, asignados o en préstamo autorizado).
+    $verTodos = tieneAccesoEspecial($conn, $noEmpleado, 'verHistorialSiniestro');
 
     $whereClause = '';
-    if ($rol == '1') {
+    if (!$verTodos) {
         $idU = intval($id_usuario);
         $whereClause = "WHERE s.id_vehiculo IN (
             SELECT inv.id_vehiculo FROM inventario inv WHERE inv.id_us_asignado = $idU OR inv.id_usuario = $idU

--- a/encabezado.php
+++ b/encabezado.php
@@ -299,8 +299,13 @@
                         </div>
                         <div class="mb-2 row g-2">    
                             <div class="col-4 col-md-4">
-                                <label for="monto" class="form-label">Monto</label>
-                                <input type="text" class="form-control" id="monto" name="monto" placeholder="$00.00" readonly required>
+                                <label for="monto" class="form-label">Monto <i class="fas fa-lock text-muted small" title="Se calcula solo"></i></label>
+                                <!-- Sigue siendo readonly (no disabled) para que gas.js lo lea, pero se
+                                     presenta como dato fijo: los usuarios reportaron que con apariencia
+                                     de input creían que podían editarlo. tabindex=-1 lo saca del tab. -->
+                                <input type="text" class="form-control-plaintext bg-body-secondary rounded px-2 fw-semibold"
+                                       id="monto" name="monto" placeholder="$00.00" readonly required
+                                       tabindex="-1" aria-readonly="true" style="cursor:not-allowed;">
                             </div>
                         
                             <div class="col-4 col-md-4">
@@ -309,8 +314,12 @@
                             </div>
 
                             <div class="col-4 col-md-4">
-                                <label for="saldo" class="form-label">Saldo</label>
-                                <input type="number" class="form-control" id="saldo" name="saldo" placeholder="$00.00" readonly required>
+                                <label for="saldo" class="form-label">Saldo <i class="fas fa-lock text-muted small" title="Se calcula solo"></i></label>
+                                <!-- Mismo tratamiento que Monto: readonly para que gas.js lo lea, pero
+                                     presentado como dato fijo. Lo calcula calcularSaldo() (monto - pagos). -->
+                                <input type="number" class="form-control-plaintext bg-body-secondary rounded px-2 fw-semibold"
+                                       id="saldo" name="saldo" placeholder="$00.00" readonly required
+                                       tabindex="-1" aria-readonly="true" style="cursor:not-allowed;">
                             </div>
                         </div>
                         <div class="mb-2 row g-2">
@@ -320,7 +329,11 @@
                             </div>
                             <div class="col-4 col-md-6">
                                 <label id="kmActual" for="kmActual" class="form-label">Km Actual</label>
-                                <input type="number" class="form-control" id="kmActualGas" name="kmActualGas" min="0" required>
+                                <!-- step=1 + inputmode numeric: la columna km_actual es INT, los
+                                     decimales solo se redondeaban en silencio. gas.js además impide
+                                     teclear el separador (ver soloKmEntero). -->
+                                <input type="number" class="form-control" id="kmActualGas" name="kmActualGas"
+                                       min="0" step="1" inputmode="numeric" required>
                             </div>
                         </div>
                     </form>
@@ -339,9 +352,11 @@
     <div class="d-flex align-items-start gap-2">
         <i class="fas fa-map-marker-alt mt-1"></i>
         <div class="flex-grow-1">
-            <div class="fw-semibold" id="avisoUbicacionTitulo">Habilita el acceso a tu ubicación</div>
+            <!-- Estos son los valores por defecto; verificarPermisoUbicacion() los ajusta
+                 según el permiso real (js/global/modals.js). -->
+            <div class="fw-semibold" id="avisoUbicacionTitulo">Se necesita la ubicación activada</div>
             <div class="small mb-1" id="avisoUbicacionMsg">
-                Para el correcto funcionamiento de Control Vehicular necesitamos acceso a tu ubicación y cookies. Acepta los permisos cuando el navegador te lo solicite.
+                Acepta el permiso de ubicación cuando el navegador te lo solicite.
             </div>
             <button type="button" class="btn btn-sm btn-warning fw-semibold mt-1" id="btnAceptarUbicacion">
                 <i class="fas fa-check me-1"></i> Habilitar ubicación
@@ -362,9 +377,9 @@
         verificarPermisoUbicacion();
     });
     window.addEventListener('load', function () {
-        var ahora = new Date();
-        var fechaCargaInput = document.getElementById("fechaCarga");
-        if (fechaCargaInput) fechaCargaInput.value = ahora.toISOString().slice(0,16);
+        // La fecha de carga ya no se pone aquí: la establece prepararModalGas() cada vez
+        // que se abre el modal (js/global/gas.js). Además, aquí se usaba toISOString()
+        // sin compensar la zona horaria, así que proponía la hora en UTC (6 h adelantada).
         var cookieValue = getCookie("noEmpleado");
         if (cookieValue) {
             var noEmpleadoInput = document.getElementById("noEmpleado");

--- a/includes/api_bootstrap.php
+++ b/includes/api_bootstrap.php
@@ -4,12 +4,46 @@ header('Content-Type: application/json');
 mysqli_set_charset($conn, "utf8mb4");
 date_default_timezone_set('America/Mexico_City');
 
-// El login (loginMaster/messbook) a veces deja $_COOKIE['id_usuario'] vacío aunque sí
-// puebla id_usuarioL (el id de usuario de CV confiable). Se normaliza aquí, una sola
-// vez, para que TODO el código que lee $_COOKIE['id_usuario'] use el id correcto —
-// sin tener que parchear cada módulo (gas, kilometraje, siniestros/consultarInventario, etc.).
-if (!empty($_COOKIE['id_usuarioL']) && intval($_COOKIE['id_usuarioL']) > 0) {
-    $_COOKIE['id_usuario'] = $_COOKIE['id_usuarioL'];
+// Normalización de $_COOKIE['id_usuario'] (ver includes/sesion_cookies.php). Está en un
+// archivo aparte porque las VISTAS también la necesitan y no pueden incluir este
+// bootstrap, que manda cabeceras JSON.
+require_once __DIR__ . '/sesion_cookies.php';
+
+/**
+ * Consulta un acceso especial de ctrlVehicular para un empleado.
+ *
+ * Se resuelve SIEMPRE en el servidor. Ojo: la cookie `rol` la escribe el cliente sin
+ * firma (index.php / validaLoginMaster.php la ponen con document.cookie), así que no
+ * sirve como barrera de permisos — cualquiera puede editarla en el navegador. Todo
+ * permiso nuevo debe pasar por aquí.
+ *
+ * @return array{tiene: bool, inf_adicional: ?string}
+ *         inf_adicional se normaliza a null cuando viene vacío o '-' (= sin filtro).
+ */
+function accesoEspecial($conn, $noEmpleado, $opcion) {
+    $vacio = ['tiene' => false, 'inf_adicional' => null];
+    $ne = intval($noEmpleado);
+    if ($ne <= 0) return $vacio;
+
+    $stmt = $conn->prepare(
+        "SELECT inf_adicional FROM mess_rrhh.accesos_especiales
+         WHERE noEmpleado = ? AND sistema = 'ctrlVehicular' AND opcion = ? AND estatus = 1
+         LIMIT 1"
+    );
+    if (!$stmt) { error_log("accesoEspecial: prepare falló - " . $conn->error); return $vacio; }
+    $stmt->bind_param("is", $ne, $opcion);
+    $stmt->execute();
+    $row = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+    if (!$row) return $vacio;
+
+    $inf = trim((string) ($row['inf_adicional'] ?? ''));
+    return ['tiene' => true, 'inf_adicional' => ($inf === '' || $inf === '-') ? null : $inf];
+}
+
+/** Atajo cuando solo importa si tiene el acceso, sin el filtro de inf_adicional. */
+function tieneAccesoEspecial($conn, $noEmpleado, $opcion) {
+    return accesoEspecial($conn, $noEmpleado, $opcion)['tiene'];
 }
 
 $tieneVehiculo = false;

--- a/includes/enviar_notificacion.php
+++ b/includes/enviar_notificacion.php
@@ -1,4 +1,79 @@
 <?php
+
+/**
+ * Envío SMTP compartido. Extraído de enviarNotificacionSolicitud() para que la
+ * notificación de resolución no duplique la configuración del servidor.
+ *
+ * NO hace echo ni manda headers a propósito: se llama a mitad de peticiones que
+ * devuelven su propio JSON (p. ej. acciones_mantenimiento.php) y cualquier salida
+ * aquí corrompería esa respuesta.
+ *
+ * @return array{ok: bool, error: string}
+ */
+function enviarCorreoMess(array $destinatarios, $asunto, $cuerpoHtml) {
+    require_once(__DIR__ . "/../PHPMailer-master/src/PHPMailer.php");
+    require_once(__DIR__ . "/../PHPMailer-master/src/SMTP.php");
+    require_once(__DIR__ . "/../PHPMailer-master/src/Exception.php");
+
+    $validos = [];
+    foreach ($destinatarios as $correo) {
+        $correo = trim((string) $correo);
+        if (filter_var($correo, FILTER_VALIDATE_EMAIL)) $validos[] = $correo;
+    }
+    if (!$validos) return ['ok' => false, 'error' => 'Sin destinatarios válidos.'];
+
+    $mail = new PHPMailer\PHPMailer\PHPMailer(true);
+    try {
+        $mail->IsSMTP();
+        $mail->SMTPDebug = 0;
+        $mail->SMTPAuth = true;
+        $mail->SMTPSecure = 'ssl';
+        $mail->Host = "smtp.gmail.com";
+        $mail->Port = 465;
+        $mail->IsHTML(true);
+        $mail->CharSet = 'UTF-8';
+        $mail->Username = "mess.programacion@gmail.com";
+        $mail->Password = "lnevdigasjodzbrq";
+        $mail->SetFrom("mess.programacion@gmail.com", "Notificacion");
+        $mail->Subject = $asunto;
+        $mail->Body    = $cuerpoHtml;
+        foreach ($validos as $correo) $mail->addAddress($correo);
+        $mail->send();
+        return ['ok' => true, 'error' => ''];
+    } catch (Exception $e) {
+        error_log("Mailer Error: " . $e->getMessage());
+        return ['ok' => false, 'error' => $e->getMessage()];
+    }
+}
+
+/**
+ * Plantilla HTML común (cabecera con imagotipo + banda de color + contenido).
+ */
+function plantillaCorreoMess($tituloBanda, $colorBanda, $contenidoHtml) {
+    return '
+    <html>
+    <head>
+        <meta charset="UTF-8">
+        <div style="text-align:center">
+            <img width="25%" src="https://www.mess.com.mx/incidencias/img/MESS_05_Imagotipo_1.png">
+            <br>
+            <hr style="border: 2px solid rgb(24, 60, 165);">
+        </div>
+    </head>
+    <body>
+        <div style="background-color:' . $colorBanda . '; color:#ffffff; padding:20px; text-align:center;
+                    font-size:22px; font-weight:bold; border-radius:8px 8px 0 0;">
+            ' . $tituloBanda . '
+        </div>
+        <div style="text-align:center">' . $contenidoHtml . '</div>
+        <br><br><br><br>
+        <div style="text-align:center">
+            <p>Este es un mensaje autom&aacute;tico, por favor no responda a este correo.</p>
+        </div>
+    </body>
+    </html>';
+}
+
 function enviarNotificacionSolicitud($tipo) {
     include __DIR__ . '/../conn.php';
     mysqli_set_charset($conn, "utf8mb4");
@@ -43,82 +118,196 @@ function enviarNotificacionSolicitud($tipo) {
     $solicitaN = $solicitaNombre;
     $tipoLabel = ($tipo === 'mantenimiento') ? 'mantenimiento' : 'prestamo';
 
-    require_once(__DIR__ . "/../PHPMailer-master/src/PHPMailer.php");
-    require_once(__DIR__ . "/../PHPMailer-master/src/SMTP.php");
-    require_once(__DIR__ . "/../PHPMailer-master/src/Exception.php");
+    $contenido = '
+        <h1>
+            ' . htmlspecialchars($solicitaN) . ' acaba hacer una solicitud de ' . $tipoLabel . ' a través del sistema de Control Vehicular
+        </h1>
+        <br><br>
+        <h2>
+            Para validar la solicitud de ' . $tipoLabel . ' por favor entra al sistema de control vehicular.<br>
+            <a href="https://messbook.com.mx/ControlVehicular"> Ver Solicitud</a>
+        </h2>';
 
-    $mail = new PHPMailer\PHPMailer\PHPMailer(true);
+    $res = enviarCorreoMess(
+        $destinatarios,
+        "Notificación del sistema de control vehicular.",
+        plantillaCorreoMess('Aviso de Nueva Solicitud', 'rgb(29, 179, 47)', $contenido)
+    );
 
-    try {
-        $mail->IsSMTP();
-        $mail->SMTPDebug = 0;
-        $mail->SMTPAuth = true;
-        $mail->SMTPSecure = 'ssl';
-        $mail->Host = "smtp.gmail.com";
-        $mail->Port = 465;
-        $mail->IsHTML(true);
-        $mail->CharSet = 'UTF-8';
-        $mail->Username = "mess.programacion@gmail.com";
-        $mail->Password = "lnevdigasjodzbrq";
-        $mail->SetFrom("mess.programacion@gmail.com", "Notificacion");
-        $mail->Subject = "Notificación del sistema de control vehicular.";
-
-        $mail->Body = '
-        <html>
-        <head>
-            <div style="text-align:center">
-                <img width="25%" src="https://www.mess.com.mx/incidencias/img/MESS_05_Imagotipo_1.png">
-                <br>
-                <hr style="border: 2px solidrgb(24, 60, 165);">
-            </div>
-            <meta charset="UTF-8">
-            <style>
-                .header {
-                    background-color:rgb(29, 179, 47);
-                    color: #ffffff;
-                    padding: 20px;
-                    text-align: center;
-                    font-size: 22px;
-                    font-weight: bold;
-                    border-radius: 8px 8px 0 0;
-                }
-            </style>
-        </head>
-        <body>
-            <div class="header">
-                Aviso de Nueva Solicitud
-            </div>
-            <div style="text-align:center">
-                <h1>
-                    ' . htmlspecialchars($solicitaN) . ' acaba hacer una solicitud de ' . $tipoLabel . ' a través del sistema de Control Vehicular
-                </h1>
-                <br><br>
-                <h2>
-                    Para validar la solicitud de ' . $tipoLabel . ' por favor entra al sistema de control vehicular.<br>
-                    <a href="https://messbook.com.mx/ControlVehicular"> Ver Solicitud</a>
-                </h2>
-            </div> <br><br><br><br>
-            <div style="text-align:center">
-                <p>Este es un mensaje autom&aacute;tico, por favor no responda a este correo.</p>
-            </div>
-        </body>
-        </html>';
-
-        foreach ($destinatarios as $correo) {
-            $correo = trim($correo);
-            if (filter_var($correo, FILTER_VALIDATE_EMAIL)) {
-                $mail->addAddress($correo);
-            }
-        }
-
-        $mail->send();
+    if ($res['ok']) {
         echo json_encode(["status" => "success", "message" => "Mensaje enviado correctamente."]);
-
-    } catch (PHPMailer\PHPMailer\Exception $e) {
-        error_log("Mailer Error: " . $e->getMessage());
-        echo json_encode(["status" => "error", "message" => "Fallo al enviar el correo: " . $e->getMessage()]);
-    } catch (Exception $e) {
-        error_log("Error general: " . $e->getMessage());
-        echo json_encode(["status" => "error", "message" => "Ocurrió un error inesperado: " . $e->getMessage()]);
+    } else {
+        echo json_encode(["status" => "error", "message" => "Fallo al enviar el correo: " . $res['error']]);
     }
+}
+
+/**
+ * Aviso de nueva solicitud de PRÉSTAMO, con los datos del préstamo.
+ *
+ * Sustituye a enviarNotificacionSolicitud('prestamo') para este flujo: aquel manda un
+ * correo genérico ("fulano acaba hacer una solicitud") sin decir de qué vehículo ni para
+ * cuándo, así que quien autoriza tenía que entrar al sistema para saber qué le pidieron.
+ *
+ * Se llama desde acciones_prestamos.php justo después del INSERT, que es donde el id ya
+ * existe; no hace echo (el que llama emite su propio JSON) y devuelve bool.
+ *
+ * @param mysqli     $conn
+ * @param int        $idPrestamo
+ * @param array|null $destinatarios Solo para pruebas: si se omite usa la lista real.
+ */
+function enviarNotificacionSolicitudPrestamo($conn, $idPrestamo, $destinatarios = null) {
+    $idPrestamo = (int) $idPrestamo;
+    if ($idPrestamo <= 0) return false;
+
+    // usuarios.id_usuario NO es único: emparejar con la fila de mayor id.
+    $sql = "SELECT p.fecha_inc_prestamo, p.fecha_fin_prestamo, p.tipo_uso,
+                   p.detalle_tipo_uso, p.Destino,
+                   inv.placa, inv.marca, inv.modelo,
+                   u.nombre AS nombre_solicitante
+            FROM prestamos p
+            LEFT JOIN inventario inv ON inv.id_vehiculo = p.id_vehiculo
+            LEFT JOIN usuarios u ON u.id = (
+                SELECT MAX(u2.id) FROM usuarios u2 WHERE u2.id_usuario = p.id_usuario
+            )
+            WHERE p.id_prestamo = ?
+            LIMIT 1";
+
+    $stmt = $conn->prepare($sql);
+    if (!$stmt) { error_log("Notif. solicitud préstamo: prepare falló - " . $conn->error); return false; }
+    $stmt->bind_param("i", $idPrestamo);
+    $stmt->execute();
+    $d = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+
+    if (!$d) { error_log("Notif. solicitud préstamo: $idPrestamo no encontrado"); return false; }
+
+    $esc = fn($v) => htmlspecialchars((string) ($v ?? ''), ENT_QUOTES, 'UTF-8');
+    $fmt = function ($f) {
+        if (empty($f) || $f === '0000-00-00 00:00:00') return '';
+        $ts = strtotime($f);
+        return $ts ? date('d/m/Y H:i', $ts) : '';
+    };
+
+    $vehiculo = trim(($d['marca'] ?? '') . ' ' . ($d['modelo'] ?? '')) . ' — ' . ($d['placa'] ?? 'S/P');
+
+    // tipo_uso trae la clase (OV/OT/Proyecto) y detalle_tipo_uso el número; juntos son
+    // lo que identifica el trabajo, así que se muestran en una sola línea.
+    $uso = trim((string) $d['tipo_uso']);
+    if (!empty($d['detalle_tipo_uso'])) $uso = trim($uso . ' — ' . $d['detalle_tipo_uso']);
+
+    $filas = '<tr><td align="right"><b>Vehículo:</b></td><td align="left">' . $esc($vehiculo) . '</td></tr>';
+    $desde = $fmt($d['fecha_inc_prestamo']);
+    $hasta = $fmt($d['fecha_fin_prestamo']);
+    if ($desde) $filas .= '<tr><td align="right"><b>Desde:</b></td><td align="left">' . $esc($desde) . '</td></tr>';
+    if ($hasta) $filas .= '<tr><td align="right"><b>Hasta:</b></td><td align="left">' . $esc($hasta) . '</td></tr>';
+    if (!empty($d['Destino'])) $filas .= '<tr><td align="right"><b>Destino:</b></td><td align="left">' . $esc($d['Destino']) . '</td></tr>';
+    if ($uso !== '')           $filas .= '<tr><td align="right"><b>Tipo de uso:</b></td><td align="left">' . $esc($uso) . '</td></tr>';
+
+    $contenido = '
+        <h2>' . $esc($d['nombre_solicitante']) . ' solicitó un préstamo de vehículo</h2>
+        <table style="margin:0 auto; font-size:15px; line-height:1.6">' . $filas . '</table>
+        <br>
+        <h3 style="font-weight:normal">
+            Para validarla entra al sistema de control vehicular.<br>
+            <a href="https://messbook.com.mx/ControlVehicular/autorizar_prestamo">Ver solicitud</a>
+        </h3>';
+
+    $res = enviarCorreoMess(
+        $destinatarios ?: ['pedro.martinez@mess.com.mx', 'rafael@mess.com.mx'],
+        'Nueva solicitud de préstamo — Control Vehicular',
+        plantillaCorreoMess('Aviso de Nueva Solicitud', 'rgb(29, 179, 47)', $contenido)
+    );
+
+    if (!$res['ok']) error_log("Notif. solicitud préstamo $idPrestamo: " . $res['error']);
+    return $res['ok'];
+}
+
+/**
+ * Avisa al SOLICITANTE que su mantenimiento fue autorizado o denegado.
+ *
+ * Antes no existía ningún aviso al resolver: autorizarMantenimiento solo hacía el
+ * UPDATE, así que el solicitante tenía que entrar a revisar por su cuenta.
+ *
+ * Recibe $conn ya abierto (lo llama acciones_mantenimiento.php) para no abrir una
+ * segunda conexión, y devuelve bool sin imprimir nada: el que llama ya emite su
+ * propio JSON.
+ *
+ * @param mysqli $conn
+ * @param int    $idMantenimiento
+ * @param string $resolucion 'AUTORIZADO' | 'DENEGADO'
+ */
+function enviarNotificacionResolucionMantenimiento($conn, $idMantenimiento, $resolucion) {
+    $idMantenimiento = (int) $idMantenimiento;
+    if ($idMantenimiento <= 0) return false;
+
+    $esAutorizado = (strtoupper($resolucion) === 'AUTORIZADO');
+
+    // usuarios.id_usuario NO es único: hay que quedarse con la fila de mayor id o el
+    // JOIN devuelve varias y el correo puede salir vacío o duplicado.
+    $sql = "SELECT m.tipo_mantenimiento, m.descripcion, m.fecha_programada, m.folio,
+                   m.costo, m.notas, m.kilometraje,
+                   inv.placa, inv.marca, inv.modelo,
+                   u.nombre AS nombre_solicitante, u.correo AS correo_solicitante
+            FROM mantenimientos m
+            LEFT JOIN inventario inv ON inv.id_vehiculo = m.id_vehiculo
+            LEFT JOIN usuarios u ON u.id = (
+                SELECT MAX(u2.id) FROM usuarios u2 WHERE u2.id_usuario = m.solicitante
+            )
+            WHERE m.id_mantenimiento = ?
+            LIMIT 1";
+
+    $stmt = $conn->prepare($sql);
+    if (!$stmt) { error_log("Notif. resolución: prepare falló - " . $conn->error); return false; }
+    $stmt->bind_param("i", $idMantenimiento);
+    $stmt->execute();
+    $datos = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+
+    if (!$datos) { error_log("Notif. resolución: mantenimiento $idMantenimiento no encontrado"); return false; }
+    if (empty($datos['correo_solicitante'])) {
+        error_log("Notif. resolución: el solicitante del mantenimiento $idMantenimiento no tiene correo");
+        return false;
+    }
+
+    $esc = fn($v) => htmlspecialchars((string) ($v ?? ''), ENT_QUOTES, 'UTF-8');
+    $vehiculo = trim($datos['marca'] . ' ' . $datos['modelo']) . ' — ' . $datos['placa'];
+
+    $filas = '<tr><td align="right"><b>Vehículo:</b></td><td align="left">' . $esc($vehiculo) . '</td></tr>'
+           . '<tr><td align="right"><b>Tipo:</b></td><td align="left">' . $esc($datos['tipo_mantenimiento']) . '</td></tr>';
+    if ($esAutorizado) {
+        if (!empty($datos['fecha_programada'])) $filas .= '<tr><td align="right"><b>Fecha programada:</b></td><td align="left">' . $esc($datos['fecha_programada']) . '</td></tr>';
+        if (!empty($datos['folio']))            $filas .= '<tr><td align="right"><b>Folio OC:</b></td><td align="left">' . $esc($datos['folio']) . '</td></tr>';
+        // El costo NO se incluye a propósito: es información interna que no le aporta
+        // nada al solicitante (decisión de la junta del 20/08).
+    }
+    if (!empty($datos['notas'])) $filas .= '<tr><td align="right"><b>Notas:</b></td><td align="left">' . $esc($datos['notas']) . '</td></tr>';
+
+    // "RECHAZADO" es solo la etiqueta que ve el usuario; en la BD el valor sigue siendo
+    // 'DENEGADO', que es lo que comparan autorizar_prestamo.php, qr_vehiculo.php y
+    // acciones_prestamos.php. Mismo criterio que verActividades.php, que ya muestra
+    // 'DENEGADO' como "Cancelado".
+    $titulo = $esAutorizado ? 'Mantenimiento autorizado' : 'Mantenimiento rechazado';
+    $color  = $esAutorizado ? 'rgb(29, 179, 47)' : 'rgb(200, 45, 45)';
+    $frase  = $esAutorizado
+        ? 'Tu solicitud de mantenimiento fue <b>autorizada</b>.'
+        : 'Tu solicitud de mantenimiento fue <b>rechazada</b>.';
+
+    $contenido = '
+        <h2>Hola ' . $esc($datos['nombre_solicitante']) . ',</h2>
+        <h3 style="font-weight:normal">' . $frase . '</h3>
+        <table style="margin:0 auto; font-size:15px; line-height:1.6">' . $filas . '</table>
+        <br>
+        <h3 style="font-weight:normal">
+            Puedes consultarla en el sistema de control vehicular.<br>
+            <a href="https://messbook.com.mx/ControlVehicular/seguimiento_mantenimiento">Ver mantenimiento</a>
+        </h3>';
+
+    $res = enviarCorreoMess(
+        [$datos['correo_solicitante']],
+        $titulo . ' — Control Vehicular',
+        plantillaCorreoMess($titulo, $color, $contenido)
+    );
+
+    if (!$res['ok']) error_log("Notif. resolución mantenimiento $idMantenimiento: " . $res['error']);
+    return $res['ok'];
 }

--- a/includes/sesion_cookies.php
+++ b/includes/sesion_cookies.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Normalización de las cookies de sesión. Incluir ANTES de leer $_COOKIE['id_usuario'].
+ *
+ * El login (loginMaster/messbook) a veces deja $_COOKIE['id_usuario'] vacío aunque sí
+ * puebla id_usuarioL, que es el id de usuario de CV confiable.
+ *
+ * Esto vivía dentro de includes/api_bootstrap.php, que solo incluyen los endpoints
+ * acciones_*.php. Las VISTAS que leen la cookie por su cuenta se quedaban fuera del
+ * arreglo: en qr_vehiculo.php eso hacía que idUsuarioActual valiera 0, que la
+ * comparación de dueño/asignado fallara y que el botón "Llenar Checklist" se ocultara
+ * — el usuario veía el aviso de checklist incompleto sin forma de actuar.
+ *
+ * Se extrajo a este archivo para que endpoints y vistas compartan la misma lógica en
+ * lugar de duplicarla.
+ */
+if (!empty($_COOKIE['id_usuarioL']) && intval($_COOKIE['id_usuarioL']) > 0) {
+    $_COOKIE['id_usuario'] = $_COOKIE['id_usuarioL'];
+}

--- a/inicio.php
+++ b/inicio.php
@@ -115,6 +115,22 @@ if ($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null) {
             cargarVehiculosDocs();
         });
 
+        // El panel se armaba una sola vez al cargar la página, así que si el usuario iba
+        // a llenar el checklist y volvía, seguía viendo el estado viejo hasta recargar a
+        // mano. Al recuperar el foco se vuelve a pedir: es justo cuando regresa de
+        // checkVehiculo o del QR. Se ignora si la pestaña sigue oculta.
+        var recargandoPanel = false;
+        function refrescarPanelVehiculos() {
+            if (recargandoPanel || document.hidden) return;
+            recargandoPanel = true;
+            cargarVehiculosDocs();
+            // Margen para no encadenar recargas si el navegador dispara varios eventos
+            // seguidos (visibilitychange + focus suelen venir juntos).
+            setTimeout(function () { recargandoPanel = false; }, 1500);
+        }
+        document.addEventListener('visibilitychange', refrescarPanelVehiculos);
+        window.addEventListener('pageshow', function (e) { if (e.persisted) refrescarPanelVehiculos(); });
+
         // Cargar vehículos prestados
         function cargarVehiculosInicio(selectVehiculo) {
             $.ajax({

--- a/js/global/gas.js
+++ b/js/global/gas.js
@@ -1,9 +1,108 @@
+/**
+ * Deja el modal listo cada vez que se abre.
+ *
+ * Hace falta porque el guardado terminaba en form.reset(), que devuelve los campos a
+ * sus valores del HTML: #fechaCarga vuelve a value="" y pierde la fecha que se le pone
+ * por JS al cargar la página, que solo corre una vez. Resultado: a la SEGUNDA carga de
+ * gas la fecha y el km salían vacíos.
+ *
+ * Además refresca monto/km/saldo desde el servidor si ya hay vehículo elegido: tras
+ * registrar una carga el saldo cambió, así que los valores que quedaron en pantalla ya
+ * no sirven.
+ */
+function prepararModalGas() {
+    var ahora = new Date();
+    // toISOString() es UTC y correría la hora; hay que compensar el offset local para
+    // que datetime-local muestre la hora real del usuario.
+    var local = new Date(ahora.getTime() - ahora.getTimezoneOffset() * 60000);
+    $('#fechaCarga').val(local.toISOString().slice(0, 16));
+
+    var id_vehiculo = $('#vehiculoAsignadoGas').val();
+    if (id_vehiculo) {
+        verPlaca('vehiculoAsignadoGas', 'kmActualGas', 'saldo');
+    } else {
+        $('#monto, #kmActualGas, #saldo').val('');
+    }
+    $('#pagos').val('');
+}
+
+/**
+ * Impide capturar decimales en el kilometraje.
+ *
+ * La columna km_actual es INT: un decimal no daba error, MySQL lo redondeaba en
+ * silencio y el usuario nunca se enteraba de que se guardó otro número.
+ *
+ * Se bloquea la TECLA en vez de limpiar el valor después, porque en un input
+ * type="number" el valor intermedio "45210." es inválido y el navegador devuelve
+ * cadena vacía: al limpiarlo se borraría todo lo que llevaba escrito. El caso de
+ * pegado sí se corrige truncando, que ahí el valor sí llega completo.
+ */
+function soloKmEntero(input) {
+    if (!input) return;
+    input.addEventListener('keydown', function (e) {
+        if (e.key === '.' || e.key === ',' || e.key === 'e' || e.key === 'E') e.preventDefault();
+    });
+    // El pegado se intercepta ANTES de que el valor llegue al campo: con coma decimal
+    // ("45210,9") el input type="number" considera el valor inválido y devuelve cadena
+    // vacía, así que después ya no queda nada que truncar.
+    input.addEventListener('paste', function (e) {
+        var texto = ((e.clipboardData || window.clipboardData) || {}).getData
+            ? (e.clipboardData || window.clipboardData).getData('text') : '';
+        if (texto && /[.,]/.test(texto)) {
+            e.preventDefault();
+            input.value = texto.split(/[.,]/)[0].replace(/[^\d]/g, '');
+        }
+    });
+    input.addEventListener('input', function () {
+        var v = String(input.value);
+        if (v !== '' && /[.,]/.test(v)) input.value = v.split(/[.,]/)[0];
+    });
+}
+
+$(function () {
+    var modalGas = document.getElementById('capturaGasModal');
+    if (modalGas) modalGas.addEventListener('show.bs.modal', prepararModalGas);
+    soloKmEntero(document.getElementById('kmActualGas'));
+});
+
+// Cerrojo de envío en curso. Deshabilitar el botón cubre el doble clic, pero no una
+// segunda llamada por teclado o desde otra pantalla (qr_vehiculo.php abre este mismo
+// modal), y cada llamada de más es una carga de gasolina duplicada en la BD.
+var _guardandoGas = false;
+
 function registrarGas() {
+    if (_guardandoGas) return;
+
     var id_vehiculo = $('#vehiculoAsignadoGas').val();
     if (!id_vehiculo) {
         Swal.fire({ icon: 'warning', title: 'Vehículo requerido', text: 'Selecciona un vehículo antes de registrar.', confirmButtonText: 'Aceptar' });
         return;
     }
+
+    // El botón es type="button" y no dispara submit, así que los `required` del HTML
+    // nunca se evalúan: sin esto los campos vacíos se enviaban en silencio. Se nombra
+    // cuál falta en vez de un "faltan campos" genérico.
+    var faltantes = [];
+    if ($('#pagos').val() === '' || isNaN(parseFloat($('#pagos').val()))) faltantes.push('Pagos');
+    if (!$('#fechaCarga').val())                                          faltantes.push('Fecha de carga');
+    if ($('#kmActualGas').val() === '')                                   faltantes.push('Km actual');
+
+    if (faltantes.length) {
+        Swal.fire({
+            icon: 'warning',
+            title: faltantes.length === 1 ? 'Falta un campo' : 'Faltan campos',
+            html: 'Completa antes de registrar:<br><b>' + faltantes.join('</b><br><b>') + '</b>',
+            confirmButtonText: 'Aceptar'
+        });
+        return;
+    }
+
+    if (parseFloat($('#kmActualGas').val()) < 0) {
+        Swal.fire({ icon: 'warning', title: 'Km inválido', text: 'El kilometraje no puede ser negativo.', confirmButtonText: 'Aceptar' });
+        return;
+    }
+
+    botonGuardando(true);
 
     // Bloquear si no tiene checklist completo para este vehículo
     $.ajax({
@@ -13,6 +112,7 @@ function registrarGas() {
         data: { accion: 'verificarChecklistGas', id_vehiculo: id_vehiculo },
         success: function (resp) {
             if (!resp.tiene) {
+                botonGuardando(false);
                 Swal.fire({
                     icon: 'warning',
                     title: 'Checklist pendiente',
@@ -43,10 +143,24 @@ function _enviarRegistroGas(id_vehiculo) {
         dataType: 'json',
         data: { accion: 'registraGas', id_vehiculo: id_vehiculo, monto: monto, pagos: pagos, saldo: saldo, fecha_carga: fecha_carga, km_actual: km_actual },
         success: function (resp) {
+            // jQuery entra aquí con cualquier HTTP 200, incluso cuando el servidor
+            // respondió {"status":"error"}. Sin esta comprobación el modal se cerraba
+            // diciendo "¡Guardado!" aunque el INSERT hubiera fallado.
+            if (!resp || resp.status !== 'success') {
+                botonGuardando(false);
+                Swal.fire({
+                    icon: 'error',
+                    title: 'No se registró la carga',
+                    text: (resp && resp.message) ? resp.message : 'El servidor rechazó el registro.',
+                    confirmButtonText: 'Aceptar'
+                });
+                return;
+            }
+
             var saldoNum = parseFloat(saldo) || 0;
 
             var modalEl = document.getElementById('capturaGasModal');
-            modalEl.addEventListener('hidden.bs.modal', function () {
+            var finalizar = function () {
                 document.querySelectorAll('.modal-backdrop').forEach(function(el) { el.remove(); });
                 document.body.classList.remove('modal-open');
                 document.body.style.overflow = '';
@@ -85,16 +199,53 @@ function _enviarRegistroGas(id_vehiculo) {
                     });
                 }
 
-                $('#formCapturaGas')[0].reset();
-            }, { once: true });
+                // Solo se limpia el importe pagado. Antes iba un form.reset() completo,
+                // que borraba también el vehículo y la fecha y dejaba el modal inservible
+                // para una segunda carga. Lo demás lo repone prepararModalGas() al abrir.
+                $('#pagos').val('');
+                botonGuardando(false);
+            };
 
-            bootstrap.Modal.getInstance(modalEl).hide();
+            // El cierre del modal no puede ser la única vía para liberar el botón: si el
+            // usuario cerró el modal a mano mientras la petición iba en vuelo, el evento
+            // 'hidden' ya pasó y nunca vuelve a dispararse, dejando el guardado trabado
+            // hasta recargar. Por eso se comprueba si sigue visible.
+            if (modalEl.classList.contains('show')) {
+                modalEl.addEventListener('hidden.bs.modal', finalizar, { once: true });
+                // getInstance() devuelve null si el modal nunca se inicializó por JS, y
+                // el .hide() reventaba dejando el modal abierto y el botón bloqueado.
+                bootstrap.Modal.getOrCreateInstance(modalEl).hide();
+            } else {
+                finalizar();
+            }
         },
         error: function (jqXHR, textStatus, errorThrown) {
             console.error('Error al registrar la carga de gasolina', errorThrown);
+            botonGuardando(false);
             Swal.fire({ icon: 'error', title: 'Error', text: 'No se pudo registrar la carga de gasolina.' });
         }
     });
+}
+
+/**
+ * Estado del botón Guardar durante el envío.
+ *
+ * Sin esto, el botón no daba señal de estar haciendo algo mientras iban las dos
+ * peticiones (verificar checklist + registrar), y volver a pulsarlo registraba la
+ * carga dos veces.
+ */
+function botonGuardando(activo) {
+    _guardandoGas = activo;
+    var btn = document.querySelector('#capturaGasModal .modal-footer .btn-primary');
+    if (!btn) return;
+    if (activo) {
+        btn.dataset.textoOriginal = btn.dataset.textoOriginal || btn.innerHTML;
+        btn.disabled = true;
+        btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> Guardando...';
+    } else {
+        btn.disabled = false;
+        if (btn.dataset.textoOriginal) btn.innerHTML = btn.dataset.textoOriginal;
+    }
 }
 
 function calcularSaldo() {

--- a/js/global/modals.js
+++ b/js/global/modals.js
@@ -6,24 +6,37 @@ function verificarPermisoUbicacion() {
     var msg    = document.getElementById('avisoUbicacionMsg');
     var btn    = document.getElementById('btnAceptarUbicacion');
 
-    // El permiso del SITIO en el navegador y el GPS del teléfono son cosas distintas:
-    // activar la ubicación del celular no desbloquea un sitio que ya fue denegado. El
-    // texto de 'denied' lo dice explícitamente porque es la confusión más común.
+    // Mensajes cortos y sin recetas de ajustes del sistema: esas instrucciones cambian
+    // por navegador y versión, y suelen apuntar a interruptores que el usuario no
+    // siempre puede tocar. Aquí solo se dice qué falta; lo accionable desde la página es
+    // el botón, y de eso se encarga aplicar().
     var TEXTOS = {
-        denied: ['Ubicación bloqueada', 'Activar el GPS del teléfono no basta: la ubicación está bloqueada para este sitio en el navegador. Permítela desde el candado de la barra de direcciones (Ajustes del sitio → Ubicación) y pulsa "Volver a comprobar".'],
-        prompt: ['Habilita el acceso a tu ubicación', 'Para el correcto funcionamiento de Control Vehicular necesitamos acceso a tu ubicación y cookies. Acepta los permisos cuando el navegador te lo solicite.']
+        denied: ['Se necesita la ubicación activada',
+                 'Permite el acceso a tu ubicación para poder usar Control Vehicular.'],
+        prompt: ['Se necesita la ubicación activada',
+                 'Acepta el permiso de ubicación cuando el navegador te lo solicite.']
     };
 
     var estadoActual = 'prompt';
 
+    // localStorage puede lanzar (Safari en navegación privada, bloqueo de datos de sitio
+    // en el navegador de una app). Antes el setItem iba ANTES de ocultar el banner, así
+    // que al lanzar dejaba el aviso puesto aunque el permiso estuviera concedido.
+    function recordar(valor) {
+        try { localStorage.setItem('cv_ubicacion_aceptada', valor); } catch (e) {}
+    }
+    function recordado() {
+        try { return localStorage.getItem('cv_ubicacion_aceptada'); } catch (e) { return null; }
+    }
+
     function aplicar(state) {
         estadoActual = state;
         if (state === 'granted') {
-            localStorage.setItem('cv_ubicacion_aceptada', '1');
-            banner.classList.add('d-none');
+            banner.classList.add('d-none');   // ocultar primero: el storage puede fallar
+            recordar('1');
             return;
         }
-        if (state === 'prompt' && localStorage.getItem('cv_ubicacion_aceptada')) {
+        if (state === 'prompt' && recordado()) {
             banner.classList.add('d-none');
             return;
         }
@@ -42,15 +55,45 @@ function verificarPermisoUbicacion() {
         banner.classList.remove('d-none');
     }
 
+    /**
+     * Sondea el permiso real. permissions.query es una OPTIMIZACIÓN (lee el estado sin
+     * abrir el diálogo y avisa de cambios), pero la FUENTE DE VERDAD es getCurrentPosition,
+     * que funciona en todos los navegadores.
+     *
+     * Este era el fallo de raíz del aviso que no se iba en iPhone: Safari no implementa
+     * permissions.query para geolocation, así que se caía al respaldo y daba 'prompt'
+     * SIN preguntarle nunca a la API de ubicación. Con el permiso concedido o no, el
+     * resultado era el mismo y el aviso se quedaba puesto.
+     *
+     * No añade diálogos extra: encabezado.php ya llama a obtenerCoordenadas() en cada
+     * carga, que hace su propio getCurrentPosition.
+     */
+    function sondear() {
+        navigator.geolocation.getCurrentPosition(
+            function () { aplicar('granted'); },
+            function (err) {
+                // Solo el código 1 (PERMISSION_DENIED) significa bloqueo. Los códigos 2 y 3
+                // (sin señal / se agotó el tiempo) son fallos de GPS, no de permiso: decir
+                // "bloqueada" ahí manda al usuario a revisar ajustes que están bien.
+                if (err && err.code === 1) aplicar('denied');
+                else                       aplicar('prompt');
+            },
+            { timeout: 8000, maximumAge: 60000 }
+        );
+    }
+
     function consultar() {
         if (navigator.permissions && navigator.permissions.query) {
             navigator.permissions.query({ name: 'geolocation' }).then(function (status) {
-                aplicar(status.state);
+                if (status.state === 'granted' || status.state === 'denied') {
+                    aplicar(status.state);
+                } else {
+                    sondear();   // 'prompt' no distingue: preguntar de verdad
+                }
                 status.onchange = function () { aplicar(status.state); };
-            }).catch(function () { aplicar('prompt'); });
+            }).catch(sondear);
         } else {
-            // Safari/iOS no implementa permissions.query para geolocation.
-            aplicar('prompt');
+            sondear();   // Safari/iOS: no hay permissions.query, la API real decide
         }
     }
 
@@ -115,7 +158,7 @@ function avisoUbicacionObligatoria() {
     Swal.fire({
         icon: 'error',
         title: 'Ubicación obligatoria',
-        text: 'No pudimos obtener tu ubicación. Habilita el GPS y el permiso de ubicación del navegador e inténtalo de nuevo.',
+        text: 'No pudimos obtener tu ubicación, y es obligatoria para continuar.',
         confirmButtonText: 'Entendido'
     });
 }

--- a/menu.php
+++ b/menu.php
@@ -22,6 +22,10 @@
     $puedeAutorizarMant = !empty($accesos['autorizaMantenimiento']);
     $puedeVerQR         = !empty($accesos['verQR']);
     $puedeCargarReportes= !empty($accesos['cargarReportes']);
+    // Los check-ins de toda la flota se gobiernan con verTodosVehiculo: quien los ve,
+    // necesariamente ve todos los vehículos. Un permiso propio permitiría concederlo
+    // sin el otro, que no tiene sentido.
+    $puedeVerCheckins   = !empty($accesos['verTodosVehiculo']);
     $muestraAdmin       = $puedeVerQR || $puedeCargarReportes;
 
     // Página activa para resaltar el item del menú
@@ -86,6 +90,18 @@
             <span>Historial de Cargas</span>
         </a>
     </li>
+
+    <?php if ($puedeVerCheckins): ?>
+    <!-- Check-ins de TODOS los vehículos. Va con verTodosVehiculo: ver los check-in de
+         toda la flota implica ver toda la flota, así que no tiene sentido un permiso
+         aparte que se pueda dar sin el otro. -->
+    <li class="nav-item<?= menuActivo('ver_checkins', $paginaActual) ?>">
+        <a class="nav-link py-2" href="ver_checkins">
+            <i class="fas fa-fw fa-clipboard-list"></i>
+            <span>Check-ins</span>
+        </a>
+    </li>
+    <?php endif; ?>
 
     <!-- Menú CheckIn -->
     <?php if (!empty($accesos['verActividades'])): ?>

--- a/prestamos.php
+++ b/prestamos.php
@@ -1,5 +1,6 @@
 <?php
     session_start();
+    require_once __DIR__ . '/includes/sesion_cookies.php';
     include 'conn.php';
 ?>
 <!DOCTYPE html>

--- a/qr_vehiculo.php
+++ b/qr_vehiculo.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/includes/sesion_cookies.php';
 
 $id_vehiculo = intval($_GET['v'] ?? 0);
 if (!$id_vehiculo) {
@@ -676,6 +677,20 @@ if (empty($_COOKIE['noEmpleado'])) {
                 return;
             }
 
+            // La sección de foto solo se muestra cuando es el primer KM de la semana
+            // (resp.primerKMDeLaSemana), y en ese caso la foto es obligatoria. Se valida
+            // aquí para no hacerle subir el formulario y rebotarlo desde el servidor,
+            // que igual lo rechaza.
+            if ($('#checkinFotoSection').is(':visible') && !$('#checkinFoto')[0].files[0]) {
+                Swal.fire({
+                    icon: 'warning',
+                    title: 'Falta la foto del KM',
+                    text: 'Es el primer registro de la semana para este vehículo: toma la foto del odómetro para continuar.',
+                    confirmButtonText: 'Aceptar'
+                });
+                return;
+            }
+
             $('#btnGuardarCheckinKM').prop('disabled', true).html('<span class="spinner-border spinner-border-sm me-1"></span> Guardando...');
 
             function enviar(latNum, lngNum) {
@@ -739,8 +754,8 @@ if (empty($_COOKIE['noEmpleado'])) {
             function gpsFallo() {
                 Swal.fire({
                     icon: 'error',
-                    title: 'Activa tu ubicación',
-                    text: 'No pudimos obtener tu ubicación, que es obligatoria para registrar el check-in. Habilita el GPS y el permiso de ubicación del navegador e inténtalo de nuevo.',
+                    title: 'Se necesita la ubicación activada',
+                    text: 'No pudimos obtener tu ubicación, y es obligatoria para registrar el check-in.',
                     confirmButtonText: 'Reintentar'
                 });
                 $('#btnGuardarCheckinKM').prop('disabled', false).text('Registrar Entrada');

--- a/ver_checkins.php
+++ b/ver_checkins.php
@@ -1,0 +1,255 @@
+<?php
+session_start();
+require_once __DIR__ . '/includes/sesion_cookies.php';
+include 'conn.php';
+if ($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null) {
+    echo '<script>window.location.assign("index")</script>';
+    exit;
+}
+
+// Guard de la vista. El endpoint valida por su cuenta (acciones_kilometraje.php,
+// accion 'consultarCheckins'); esto solo evita mostrar la página vacía a quien no
+// tiene el acceso.
+//
+// El permiso es verTodosVehiculo: ver los check-in de toda la flota implica ver toda
+// la flota, así que no se creó un permiso aparte que pudiera darse sin el otro.
+$stmtAcc = $conn->prepare(
+    "SELECT 1 FROM mess_rrhh.accesos_especiales
+     WHERE noEmpleado = ? AND sistema = 'ctrlVehicular' AND opcion = 'verTodosVehiculo' AND estatus = 1
+     LIMIT 1"
+);
+$noEmpVista = intval($_COOKIE['noEmpleado']);
+$stmtAcc->bind_param("i", $noEmpVista);
+$stmtAcc->execute();
+$tieneAcceso = (bool) $stmtAcc->get_result()->fetch_assoc();
+$stmtAcc->close();
+if (!$tieneAcceso) {
+    echo '<script>window.location.assign("inicio")</script>';
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Control Vehicular - Check-ins</title>
+    <!-- MESS Design System -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
+    <link href="css/mess-ds.css" rel="stylesheet">
+</head>
+<body id="page-top">
+    <div id="wrapper">
+        <?php include 'menu.php'; ?>
+        <div id="content-wrapper" class="d-flex flex-column">
+            <div id="content">
+                <?php include 'encabezado.php'; ?>
+                <div class="container-fluid">
+
+                    <div class="d-sm-flex align-items-center justify-content-between mb-3">
+                        <h1 class="h3 mb-0 text-black-800">Check-ins de vehículos</h1>
+                        <span class="badge bg-secondary fs-6" id="badgeTotal"></span>
+                    </div>
+
+                    <div class="card shadow mb-3">
+                        <div class="card-body py-3">
+                            <div class="row g-2 align-items-end">
+                                <div class="col-6 col-md-3">
+                                    <label for="fDesde" class="form-label mb-1 small fw-semibold">Desde</label>
+                                    <input type="date" class="form-control form-control-sm" id="fDesde">
+                                </div>
+                                <div class="col-6 col-md-3">
+                                    <label for="fHasta" class="form-label mb-1 small fw-semibold">Hasta</label>
+                                    <input type="date" class="form-control form-control-sm" id="fHasta">
+                                </div>
+                                <div class="col-12 col-md-4">
+                                    <label for="fVehiculo" class="form-label mb-1 small fw-semibold">Vehículo</label>
+                                    <select class="form-select form-select-sm" id="fVehiculo">
+                                        <option value="0">Todos</option>
+                                    </select>
+                                </div>
+                                <div class="col-12 col-md-2 d-grid">
+                                    <button class="btn btn-primary btn-sm" id="btnBuscar">
+                                        <i class="fas fa-search me-1"></i> Buscar
+                                    </button>
+                                </div>
+                            </div>
+                            <div class="row g-2 mt-1">
+                                <div class="col-12">
+                                    <input type="text" class="form-control form-control-sm" id="fTexto"
+                                           placeholder="Filtrar por placa, usuario, OT/OV o notas...">
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="card shadow mb-4">
+                        <div class="card-body p-0">
+                            <div class="table-responsive">
+                                <table class="table table-hover table-sm align-middle mb-0" id="tablaCheckins">
+                                    <thead class="table-light">
+                                        <tr>
+                                            <th>Fecha</th>
+                                            <th>Vehículo</th>
+                                            <th>Usuario</th>
+                                            <th>Tipo</th>
+                                            <th class="text-end">Km</th>
+                                            <th>OT / OV</th>
+                                            <th class="text-center">Foto</th>
+                                            <th class="text-center">Ubicación</th>
+                                            <th>Notas</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody></tbody>
+                                </table>
+                            </div>
+                            <div id="sinResultados" class="text-center text-muted py-5" style="display:none;">
+                                <i class="fas fa-clipboard-list fa-3x mb-3 d-block"></i>
+                                No hay check-ins en el rango seleccionado.
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+            </div>
+            <footer class="sticky-footer bg-white">
+                <div class="container my-auto"><div class="copyright text-center my-auto">
+                    <span>Grupo MESS</span>
+                </div></div>
+            </footer>
+        </div>
+    </div>
+
+    <a class="scroll-to-top rounded" href="#page-top"><i class="fas fa-angle-up"></i></a>
+
+<script>
+    var filas = [];
+
+    function esc(s) {
+        return $('<div>').text(s == null ? '' : s).html();
+    }
+
+    function fmtFecha(f) {
+        if (!f) return '';
+        var p = f.split(/[- :]/);
+        return p[2] + '/' + p[1] + '/' + p[0] + ' ' + (p[3] || '00') + ':' + (p[4] || '00');
+    }
+
+    // Cada tipo con su color, para poder barrer la tabla de un vistazo. Un INICIO sin
+    // FINALIZACION posterior sale como "Abierto": es el caso que hay que perseguir,
+    // porque el usuario nunca cerró la actividad.
+    function badgeTipo(f) {
+        if (f.tipo_actividad === 'INICIO') {
+            return f.abierto == 1
+                ? '<span class="badge bg-warning text-dark">Abierto</span>'
+                : '<span class="badge bg-success">Entrada</span>';
+        }
+        if (f.tipo_actividad === 'FINALIZACION') return '<span class="badge bg-secondary">Salida</span>';
+        if (f.tipo_actividad === 'KM_SEMANAL')   return '<span class="badge bg-info text-dark">Km semanal</span>';
+        return '<span class="badge bg-light text-dark">' + esc(f.tipo_actividad) + '</span>';
+    }
+
+    function pintar() {
+        var texto = $('#fTexto').val().toLowerCase().trim();
+        var $tb = $('#tablaCheckins tbody').empty();
+        var mostradas = 0;
+
+        filas.forEach(function (f) {
+            if (texto) {
+                var blob = [f.placa, f.usuario, f.ot, f.notas, f.marca, f.modelo].join(' ').toLowerCase();
+                if (blob.indexOf(texto) === -1) return;
+            }
+            mostradas++;
+
+            var vehiculo = esc(f.placa || 'S/P');
+            if (f.marca || f.modelo) {
+                vehiculo += '<br><span class="small text-muted">' + esc([f.marca, f.modelo].filter(Boolean).join(' ')) + '</span>';
+            }
+
+            var foto = f.foto_url
+                ? '<a href="' + esc(f.foto_url) + '" target="_blank" rel="noopener" title="Ver foto"><i class="fas fa-image"></i></a>'
+                : '<span class="text-muted">&mdash;</span>';
+
+            // Sin coordenadas no se pinta nada: un enlace de mapa vacío solo estorba.
+            var ubic = f.coordenadas
+                ? '<a href="https://www.google.com/maps?q=' + encodeURIComponent(f.coordenadas) + '" target="_blank" rel="noopener" title="' + esc(f.coordenadas) + '"><i class="fas fa-map-marker-alt"></i></a>'
+                : '<span class="text-muted">&mdash;</span>';
+
+            $tb.append(
+                '<tr' + (f.abierto == 1 ? ' class="table-warning"' : '') + '>' +
+                '<td class="text-nowrap small">' + fmtFecha(f.fecha_actividad) + '</td>' +
+                '<td class="small">' + vehiculo + '</td>' +
+                '<td class="small">' + esc(f.usuario || 'S/R') + '</td>' +
+                '<td>' + badgeTipo(f) + '</td>' +
+                '<td class="text-end small">' + (f.km_actual ? Number(f.km_actual).toLocaleString('es-MX') : '') + '</td>' +
+                '<td class="small">' + esc(f.ot || '') + '</td>' +
+                '<td class="text-center">' + foto + '</td>' +
+                '<td class="text-center">' + ubic + '</td>' +
+                '<td class="small text-muted">' + esc(f.notas || '') + '</td>' +
+                '</tr>'
+            );
+        });
+
+        $('#sinResultados').toggle(mostradas === 0);
+        var abiertos = filas.filter(function (f) { return f.abierto == 1; }).length;
+        $('#badgeTotal').text(mostradas + ' registros' + (abiertos ? ' · ' + abiertos + ' sin cerrar' : ''));
+    }
+
+    function cargar() {
+        $('#tablaCheckins tbody').html('<tr><td colspan="9" class="text-center py-4"><i class="fas fa-spinner fa-spin"></i></td></tr>');
+        $.ajax({
+            url: 'acciones_kilometraje.php',
+            method: 'POST',
+            dataType: 'json',
+            data: {
+                accion: 'consultarCheckins',
+                desde: $('#fDesde').val(),
+                hasta: $('#fHasta').val(),
+                id_vehiculo: $('#fVehiculo').val()
+            },
+            success: function (resp) {
+                if (!resp || resp.status !== 'success') {
+                    $('#tablaCheckins tbody').empty();
+                    Swal.fire({ icon: 'error', title: 'Error', text: (resp && resp.message) ? resp.message : 'No se pudieron cargar los check-ins.' });
+                    return;
+                }
+                // Array.isArray antes del forEach: las acciones_*.php devuelven un objeto
+                // de error cuando algo falla y iterar sobre él rompe en silencio.
+                filas = Array.isArray(resp.checkins) ? resp.checkins : [];
+                $('#fDesde').val(resp.desde);
+                $('#fHasta').val(resp.hasta);
+                pintar();
+            },
+            error: function () {
+                $('#tablaCheckins tbody').empty();
+                Swal.fire({ icon: 'error', title: 'Error', text: 'No se pudieron cargar los check-ins.' });
+            }
+        });
+    }
+
+    $(document).ready(function () {
+        // Lista de vehículos para el filtro. Se reutiliza la acción que ya existe.
+        $.ajax({
+            url: 'AccionesCheckVehiculo.php',
+            method: 'POST',
+            dataType: 'json',
+            data: { opcion: 'llenaTVehiculosAsignados', cookieNoEmpleado: getCookie('noEmpleado') },
+            success: function (data) {
+                if (!Array.isArray(data)) return;
+                data.forEach(function (v) {
+                    $('#fVehiculo').append('<option value="' + v.id + '">' + esc(v.placa + ' - ' + (v.modelo || '')) + '</option>');
+                });
+            }
+        });
+
+        cargar();
+        $('#btnBuscar').on('click', cargar);
+        $('#fTexto').on('input', pintar);
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
Notificaciones. Autorizar un mantenimiento no avisaba a nadie: el UPDATE corría y el solicitante tenía que entrar a mirar. Ahora recibe correo al autorizarse o rechazarse, con vehículo, tipo, fecha, folio y notas. El envío SMTP se extrajo a enviarCorreoMess() para no duplicarlo, y autorizar/denegar pasaron a sentencias preparadas.

El correo de solicitud de préstamo llevaba tiempo sin enviarse: la llamada a correoPrestamo.php estaba comentada. Se movió al servidor, tras el INSERT, donde ya existe el id y se pueden incluir vehículo, fechas, destino y tipo de uso.

Accesos. El historial de siniestros filtraba con la cookie `rol`, que la escribe el cliente sin firma: bastaba poner rol=3 en el navegador para ver los siniestros de toda la empresa. Migrado a accesos_especiales, que se resuelve en servidor. Se añade el helper accesoEspecial() en api_bootstrap.php y las opciones verHistorialSiniestro y verHistorialPrestamos.

Sesión. La normalización de $_COOKIE['id_usuario'] desde id_usuarioL vivía en api_bootstrap.php, que solo incluyen los endpoints. Las vistas que leen la cookie por su cuenta se quedaban fuera: en qr_vehiculo.php eso hacía que idUsuarioActual valiera 0 y el botón "Llenar Checklist" se ocultara. Extraída a includes/sesion_cookies.php y aplicada también en las vistas.

Gasolina. El guardado terminaba en form.reset(), que devolvía los campos a sus valores del HTML y dejaba fecha y km vacíos en la segunda carga. El botón no comprobaba la respuesta del servidor: mostraba "¡Guardado!" aunque el INSERT hubiera fallado, y sin bloqueo el doble clic registraba dos cargas. El servidor ahora valida y normaliza (la fecha llegaba como datetime-local a una columna DATE, y km_actual es INT pero aceptaba decimales que MySQL redondeaba en silencio). Monto y saldo se presentan como dato fijo: eran readonly pero parecían editables.

Checklist. El estado de cada subárea se calculaba comparando buen_estado contra 'Si', valor que no existe en ninguna de las 480 filas de la BD (solo hay '0', '1' y vacío). El panel pintaba TODO en rojo desde siempre, en Control Vehicular y en messbook, y el semáforo contaba 0 de 10. Ahora distingue bien, mal y sin responder. El panel además se refresca al volver a la pestaña, que es cuando el usuario regresa de llenar el checklist.

Check-in QR. La foto del odómetro no era obligatoria en el primer registro de la semana: ni el front ni el servidor la exigían. Ahora se valida en ambos, recalculando en servidor si es el primero de la semana.

Ubicación. El estado del permiso se deducía de permissions.query, que Safari no implementa para geolocation: se caía al respaldo y mostraba el aviso sin preguntarle nunca a la API real, con el permiso concedido o no. Ahora getCurrentPosition es la fuente de verdad. Los mensajes ya no prescriben rutas de ajustes que el usuario no siempre puede tocar.

Vista nueva ver_checkins.php: todos los check-in en crudo, una fila por registro, marcando los INICIO que nunca se cerraron. No cruza pares como "Actividades", que solo muestra viajes cerrados y esconde justo los que hay que auditar. Acceso por verTodosVehiculo.