### PR TITLE
Retro 21/08: checklist, anomalías, recargas de gas y títulos

### DIFF
--- a/AccionesCheckVehiculo.php
+++ b/AccionesCheckVehiculo.php
@@ -264,6 +264,14 @@ function getFotoInfo($fileKey, $placa, $tipo, $subdir) {
         return ['ruta' => "{$dir}/{$nombre}", 'dir' => $dir, 'nombre' => $nombre, 'tmp' => $archivo['tmp_name'], 'subir' => true];
     }
     $rutaExistente = !empty($_POST["ruta_{$fileKey}"]) ? $_POST["ruta_{$fileKey}"] : null;
+
+    // Centinela que manda quitarFoto() en checkVehiculo.php. Distingue "el usuario quitó
+    // la foto" de "esta petición simplemente no la incluye": sin esto, al conservar la
+    // ruta en el segundo caso tampoco se podría borrar en el primero.
+    if ($rutaExistente === '__BORRAR__') {
+        return ['ruta' => '', 'dir' => null, 'nombre' => null, 'tmp' => null, 'subir' => false, 'limpiar' => true];
+    }
+
     return ['ruta' => $rutaExistente ?? '', 'dir' => null, 'nombre' => null, 'tmp' => null, 'subir' => false];
 }
 
@@ -294,11 +302,17 @@ function upsertChecklistSeccion($conn, $tabla, $id_checklist, $campos, $fotoKey,
     $foto = getFotoInfo($fotoKey, $placa, $fotoTipo, $subdir);
     $fotoSql = $foto['ruta'] !== null ? "'{$foto['ruta']}'" : "NULL";
 
+    // Si en esta petición no viene ni archivo nuevo ni ruta previa, la columna foto NO
+    // se toca: se conserva lo que ya estuviera guardado. Antes se escribía cadena vacía,
+    // así que cualquier guardado parcial BORRABA la ruta de una foto ya subida. Con el
+    // guardado automático al cambiar de apartado eso pasaría en cada paso.
+    $conservarFoto = !$foto['subir'] && empty($foto['limpiar']) && ($foto['ruta'] === '' || $foto['ruta'] === null);
+
     $r = mysqli_query($conn, "SELECT id_checklist FROM $tabla WHERE id_checklist='$id_checklist'");
     if ($r && mysqli_num_rows($r) > 0) {
         $sets = [];
         foreach ($campos as $col => $val) { $sets[] = "$col='$val'"; }
-        $sets[] = "foto=$fotoSql";
+        if (!$conservarFoto) $sets[] = "foto=$fotoSql";
         $sql = "UPDATE $tabla SET " . implode(', ', $sets) . " WHERE id_checklist='$id_checklist'";
     } else {
         $cols = array_keys($campos);
@@ -319,11 +333,15 @@ function upsertChecklistDocumentacion($conn, $id_checklist, $t_documento, $campo
     $foto = getFotoInfo($fotoKey, $placa, $fotoTipo, $subdir);
     $fotoSql = $foto['ruta'] !== null ? "'{$foto['ruta']}'" : "NULL";
 
+    // Mismo criterio que upsertChecklistSeccion: sin archivo nuevo ni ruta previa, la
+    // columna foto se deja como está en vez de sobrescribirla con cadena vacía.
+    $conservarFoto = !$foto['subir'] && empty($foto['limpiar']) && ($foto['ruta'] === '' || $foto['ruta'] === null);
+
     $r = mysqli_query($conn, "SELECT id_checklist FROM checklist_documentacion WHERE id_checklist='$id_checklist' AND t_documento='$t_documento'");
     if ($r && mysqli_num_rows($r) > 0) {
         $sets = [];
         foreach ($campos as $col => $val) { $sets[] = "$col='$val'"; }
-        $sets[] = "foto=$fotoSql";
+        if (!$conservarFoto) $sets[] = "foto=$fotoSql";
         $sql = "UPDATE checklist_documentacion SET " . implode(', ', $sets) . " WHERE id_checklist='$id_checklist' AND t_documento='$t_documento'";
     } else {
         $allCols = ['id_checklist', 't_documento'];
@@ -353,9 +371,41 @@ $TABLAS_CHECKLIST = [
 ];
 
 if ($opcion == 'guardarCheckIn') {
-    $resBorrador = mysqli_query($conn, "SELECT id_checklist FROM checklist WHERE id_vehiculo='$id_coche' AND estatus='borrador' ORDER BY fecha DESC LIMIT 1");
+    // A qué checklist escribir. Antes se buscaba siempre "el último borrador del
+    // vehículo", así que empezar un checklist nuevo SOBRESCRIBÍA el anterior: la opción
+    // "No, empezar de nuevo" del cliente no creaba nada, solo dejaba el formulario en
+    // blanco y luego el guardado pisaba el borrador viejo.
+    //
+    //   id_checklist  -> el cliente ya sabe en cuál trabaja (se lo devolvimos al guardar)
+    //   nuevo=1       -> el usuario eligió empezar de cero: se fuerza uno nuevo
+    //   ninguno       -> comportamiento anterior: continuar el último borrador
+    $id_checklist_post = intval($_POST['id_checklist'] ?? 0);
+    $forzarNuevo       = !empty($_POST['nuevo']);
+    $id_checklist      = 0;
 
-    if ($resBorrador && mysqli_num_rows($resBorrador) > 0) {
+    if ($id_checklist_post > 0) {
+        $chk = mysqli_query($conn, "SELECT id_checklist FROM checklist WHERE id_checklist='$id_checklist_post' AND id_vehiculo='$id_coche' LIMIT 1");
+        if ($chk && mysqli_num_rows($chk) > 0) $id_checklist = $id_checklist_post;
+    }
+
+    $resBorrador = null;
+    if (!$id_checklist && !$forzarNuevo) {
+        $resBorrador = mysqli_query($conn, "SELECT id_checklist FROM checklist WHERE id_vehiculo='$id_coche' AND estatus='borrador' ORDER BY fecha DESC LIMIT 1");
+    }
+
+    if ($id_checklist) {
+        if (!mysqli_query($conn, "UPDATE checklist SET fecha=NOW(), motivo='$motivo', estatus='$estatus' WHERE id_checklist='$id_checklist'")) {
+            die(json_encode(array("error" => "Failed to update checklist: " . mysqli_error($conn))));
+        }
+        if ($estatus === 'completo') {
+            $resHuerfanos = mysqli_query($conn, "SELECT id_checklist FROM checklist WHERE id_vehiculo='$id_coche' AND estatus='borrador' AND id_checklist <> '$id_checklist'");
+            while ($rowH = mysqli_fetch_assoc($resHuerfanos)) {
+                $hId = $rowH['id_checklist'];
+                foreach ($TABLAS_CHECKLIST as $t) { mysqli_query($conn, "DELETE FROM $t WHERE id_checklist='$hId'"); }
+                mysqli_query($conn, "DELETE FROM checklist WHERE id_checklist='$hId'");
+            }
+        }
+    } elseif ($resBorrador && mysqli_num_rows($resBorrador) > 0) {
         $rowBorrador = mysqli_fetch_assoc($resBorrador);
         $id_checklist = $rowBorrador['id_checklist'];
         if (!mysqli_query($conn, "UPDATE checklist SET fecha=NOW(), motivo='$motivo', estatus='$estatus' WHERE id_checklist='$id_checklist'")) {
@@ -412,7 +462,13 @@ if ($opcion == 'guardarCheckIn') {
         if (!$resultado) { die(json_encode(["error" => "Failed to insert documentacion $d[0]: " . mysqli_error($conn)])); }
     }
 
-    echo json_encode(array("success" => "Checklist and related data inserted successfully."));
+    // Se devuelve el id para que el cliente sepa en qué checklist está trabajando y lo
+    // reenvíe en los siguientes guardados. Sin esto, cada guardado volvía a adivinar
+    // "el último borrador del vehículo" y podía escribir en otro distinto.
+    echo json_encode(array(
+        "success"      => "Checklist and related data inserted successfully.",
+        "id_checklist" => $id_checklist
+    ));
 }
 
 // ======== CARGAR BORRADOR ========
@@ -428,7 +484,9 @@ if ($opcion == 'cargarBorrador') {
 
     $rowMain = mysqli_fetch_assoc($resBorrador);
     $id_checklist_borrador = $rowMain['id_checklist'];
-    $data = ['found' => true, 'motivo' => $rowMain['motivo']];
+    // id_checklist va en la respuesta para que el cliente sepa cuál está continuando y
+    // lo reenvíe al guardar, en vez de dejar que el servidor lo adivine cada vez.
+    $data = ['found' => true, 'id_checklist' => $id_checklist_borrador, 'motivo' => $rowMain['motivo']];
 
     $seccionesFisicas = [
         'asientos'        => 'checklist_asientos',

--- a/acciones_anomalias.php
+++ b/acciones_anomalias.php
@@ -47,11 +47,17 @@ if ($accion === 'registrarAnomalia') {
         }
     }
 
+    // La ubicación es opcional (columna NULL): si el GPS falla, la anomalía se registra
+    // igual. Es un reporte de mantenimiento, no un siniestro, así que no vale la pena
+    // bloquear al usuario por no tener señal.
+    $coordenadas = trim($_POST['coordenadas'] ?? '');
+    if ($coordenadas === '') $coordenadas = null;
+
     $stmt = $conn->prepare(
-        "INSERT INTO anomalias (id_vehiculo, id_usuario, descripcion, foto_ruta, fecha)
-         VALUES (?, ?, ?, ?, NOW())"
+        "INSERT INTO anomalias (id_vehiculo, id_usuario, descripcion, foto_ruta, coordenadas, fecha)
+         VALUES (?, ?, ?, ?, ?, NOW())"
     );
-    $stmt->bind_param("iiss", $id_vehiculo, $id_usuario, $descripcion, $foto_ruta);
+    $stmt->bind_param("iisss", $id_vehiculo, $id_usuario, $descripcion, $foto_ruta, $coordenadas);
 
     if ($stmt->execute()) {
         echo json_encode(['success' => true]);
@@ -59,6 +65,53 @@ if ($accion === 'registrarAnomalia') {
         echo json_encode(['success' => false, 'error' => 'Error al guardar en la base de datos.']);
     }
     $stmt->close();
+    exit;
+}
+
+/**
+ * Feed del historial de anomalías.
+ *
+ * Mismo criterio de acceso que el historial de siniestros (obtenerFeedSiniestros en
+ * acciones_siniestro.php): se reutiliza la opción verHistorialSiniestro porque quien
+ * puede ver los siniestros de toda la flota es la misma gente que necesita ver las
+ * anomalías; separarlas obligaría a dar dos permisos que siempre van juntos.
+ *
+ * Sin ese acceso, cada quien ve solo las de sus vehículos (propios, asignados o en
+ * préstamo autorizado). Nunca se filtra con la cookie `rol`, que la escribe el cliente.
+ */
+if ($accion === 'obtenerFeedAnomalias') {
+    $noEmpleado = $_COOKIE['noEmpleado'] ?? 0;
+    $verTodas   = tieneAccesoEspecial($conn, $noEmpleado, 'verHistorialSiniestro');
+
+    $where = '';
+    if (!$verTodas) {
+        $idU = intval($id_usuario);
+        $where = "WHERE a.id_vehiculo IN (
+            SELECT inv.id_vehiculo FROM inventario inv WHERE inv.id_us_asignado = $idU OR inv.id_usuario = $idU
+            UNION
+            SELECT p.id_vehiculo FROM prestamos p WHERE p.id_usuario = $idU AND p.estatus = 'AUTORIZADO'
+        )";
+    }
+
+    // usuarios.id_usuario no es único: se empareja con la fila de mayor id para que el
+    // JOIN no multiplique las anomalías.
+    $sql = "SELECT a.id, a.id_vehiculo, a.descripcion, a.foto_ruta, a.coordenadas,
+                   a.fecha, DATE(a.fecha) AS fecha_dia,
+                   inv.placa, inv.modelo, inv.marca, inv.color, inv.anio,
+                   IFNULL(NULLIF(TRIM(CONCAT(IFNULL(rrhh.nombres,''),' ',IFNULL(rrhh.apellidos,''))),''), u.nombre) AS nombre_usuario
+            FROM anomalias a
+            INNER JOIN inventario inv ON inv.id_vehiculo = a.id_vehiculo
+            LEFT JOIN usuarios u ON u.id = (
+                SELECT MAX(u2.id) FROM usuarios u2 WHERE u2.id_usuario = a.id_usuario
+            )
+            LEFT JOIN mess_rrhh.usuarios rrhh ON rrhh.noEmpleado = u.noEmpleado
+            $where
+            ORDER BY a.fecha DESC, a.id DESC";
+
+    $res = $conn->query($sql);
+    $anomalias = [];
+    if ($res) { while ($row = $res->fetch_assoc()) $anomalias[] = $row; }
+    echo json_encode($anomalias);
     exit;
 }
 

--- a/acciones_gas.php
+++ b/acciones_gas.php
@@ -298,26 +298,56 @@ $fecha_registro = isset($_POST['fecha_registro']) ? $_POST['fecha_registro'] : n
             ? $row_v['placa'] . ' - ' . $row_v['modelo'] . ' ' . $row_v['marca']
             : 'Vehículo #' . $id_vehiculo_req;
 
-        require_once __DIR__ . '/PHPMailer-master/src/PHPMailer.php';
-        require_once __DIR__ . '/PHPMailer-master/src/SMTP.php';
-        require_once __DIR__ . '/PHPMailer-master/src/Exception.php';
+        // Km recorridos con el crédito que se está agotando. El ciclo arranca en la carga
+        // donde el monto vuelve al crédito completo (4000, ver verPlaca en
+        // js/global/vehiculos.js), así que el recorrido es la diferencia entre la última
+        // lectura del odómetro y la de esa carga. Sirve para juzgar si el consumo fue
+        // razonable antes de reponer.
+        // Se toma la ÚLTIMA lectura por fecha, no MAX(km_actual): hay dedazos en la
+        // captura (por ejemplo un 1681614 entre lecturas de ~169000) y con MAX salía un
+        // recorrido de más de un millón de kilómetros.
+        $stmtKm = $conn->prepare(
+            "SELECT
+                (SELECT km_actual FROM carga_gasolina
+                   WHERE id_vehiculo = ? ORDER BY fecha_carga DESC, id DESC LIMIT 1) AS km_ultimo,
+                (SELECT km_actual FROM carga_gasolina
+                   WHERE id_vehiculo = ? AND monto >= 4000
+                   ORDER BY fecha_carga DESC, id DESC LIMIT 1) AS km_inicio"
+        );
+        $stmtKm->bind_param("ii", $id_vehiculo_req, $id_vehiculo_req);
+        $stmtKm->execute();
+        $rowKm = $stmtKm->get_result()->fetch_assoc();
+        $stmtKm->close();
 
-        $mail = new PHPMailer\PHPMailer\PHPMailer(true);
-        try {
-            $mail->IsSMTP();
-            $mail->SMTPDebug  = 0;
-            $mail->SMTPAuth   = true;
-            $mail->SMTPSecure = 'ssl';
-            $mail->Host       = 'smtp.gmail.com';
-            $mail->Port       = 465;
-            $mail->IsHTML(true);
-            $mail->CharSet  = 'UTF-8';
-            $mail->Username = 'mess.programacion@gmail.com';
-            $mail->Password = 'lnevdigasjodzbrq';
-            $mail->SetFrom('mess.programacion@gmail.com', 'Control Vehicular');
-            $mail->Subject  = 'Solicitud de reposición de crédito de gasolina';
-            $mail->addAddress('cuentasdegastos@mess.com.mx');
-            $mail->Body = '
+        $kmUltimo = isset($rowKm['km_ultimo']) ? intval($rowKm['km_ultimo']) : 0;
+        $kmInicio = isset($rowKm['km_inicio']) ? intval($rowKm['km_inicio']) : 0;
+
+        // Tope de coherencia: un crédito de $4,000 rinde del orden de 1,500 km. Un
+        // resultado muy por encima solo puede venir de una lectura mal capturada, y es
+        // preferible no decir nada a mandar una cifra absurda en el correo.
+        $LIMITE_KM_CREDITO = 10000;
+        $kmRecorrido = null;
+        if ($kmUltimo > 0 && $kmInicio > 0 && $kmUltimo >= $kmInicio) {
+            $diff = $kmUltimo - $kmInicio;
+            if ($diff <= $LIMITE_KM_CREDITO) $kmRecorrido = $diff;
+        }
+
+        $kmRecorridoTxt = $kmRecorrido !== null
+            ? number_format($kmRecorrido) . ' km'
+            : 'Sin datos suficientes';
+        $kmUltimoTxt = $kmUltimo > 0 ? number_format($kmUltimo) . ' km' : 'S/R';
+
+        // Se reutiliza enviarCorreoMess() (includes/enviar_notificacion.php) en vez de
+        // repetir aquí la configuración SMTP. Además acepta un destinatario alterno, que
+        // sirve para mandar muestras sin escribirle a cuentas de gastos; el parámetro NO
+        // se lee del POST, así que no se puede desviar el correo desde el cliente.
+        require_once __DIR__ . '/includes/enviar_notificacion.php';
+
+        $destinatariosGas = isset($destinatariosGasPrueba) && $destinatariosGasPrueba
+            ? $destinatariosGasPrueba
+            : ['cuentasdegastos@mess.com.mx'];
+
+        $cuerpoGas = '
             <html><body style="font-family:Arial,sans-serif;color:#222">
             <div style="text-align:center">
                 <img width="20%" src="https://www.mess.com.mx/incidencias/img/MESS_05_Imagotipo_1.png">
@@ -336,6 +366,14 @@ $fecha_registro = isset($_POST['fecha_registro']) ? $_POST['fecha_registro'] : n
                         <td style="padding:10px;border:1px solid #ccc">$' . number_format($saldo_actual, 2) . '</td>
                     </tr>
                     <tr style="background:#f0f4ff">
+                        <td style="padding:10px;border:1px solid #ccc"><strong>Km recorridos con este crédito</strong></td>
+                        <td style="padding:10px;border:1px solid #ccc">' . $kmRecorridoTxt . '</td>
+                    </tr>
+                    <tr>
+                        <td style="padding:10px;border:1px solid #ccc"><strong>Kilometraje actual</strong></td>
+                        <td style="padding:10px;border:1px solid #ccc">' . $kmUltimoTxt . '</td>
+                    </tr>
+                    <tr style="background:#f0f4ff">
                         <td style="padding:10px;border:1px solid #ccc"><strong>Fecha</strong></td>
                         <td style="padding:10px;border:1px solid #ccc">' . date('d/m/Y H:i') . '</td>
                     </tr>
@@ -350,11 +388,153 @@ $fecha_registro = isset($_POST['fecha_registro']) ? $_POST['fecha_registro'] : n
             <p style="text-align:center;color:#888;font-size:12px">Mensaje automático — no responder.</p>
             </body></html>';
 
-            $mail->send();
+        // La solicitud se PERSISTE antes de enviar el correo. Hasta ahora solo se mandaba
+        // el aviso y no quedaba rastro: no se podía saber cuántas había pendientes, quién
+        // las resolvió ni cuándo. Es lo que alimenta la vista de validación.
+        $idSolicitante = intval($_COOKIE['id_usuario'] ?? 0);
+        $stmtSol = $conn->prepare(
+            "INSERT INTO solicitudes_gas
+                (id_vehiculo, id_usuario, saldo_solicitud, km_actual, km_recorrido, estatus, fecha)
+             VALUES (?, ?, ?, ?, ?, 'PENDIENTE', NOW())"
+        );
+        $kmUltimoBd   = $kmUltimo > 0 ? $kmUltimo : null;
+        $kmRecorridoBd = $kmRecorrido;   // null si no se pudo calcular con certeza
+        $stmtSol->bind_param("iidii", $id_vehiculo_req, $idSolicitante, $saldo_actual, $kmUltimoBd, $kmRecorridoBd);
+        $stmtSol->execute();
+        $stmtSol->close();
+
+        $resGas = enviarCorreoMess($destinatariosGas, 'Solicitud de reposición de crédito de gasolina', $cuerpoGas);
+        if ($resGas['ok']) {
             echo json_encode(['status' => 'success', 'message' => 'Solicitud enviada correctamente al encargado.']);
-        } catch (Exception $e) {
-            echo json_encode(['status' => 'error', 'message' => 'Error al enviar: ' . $e->getMessage()]);
+        } else {
+            echo json_encode(['status' => 'error', 'message' => 'Error al enviar: ' . $resGas['error']]);
         }
+        exit;
+    }
+
+    /**
+     * Listado de solicitudes de recarga para la vista de validación.
+     *
+     * Ver la lista y resolverla son permisos distintos: verSolicitudesGas deja consultar
+     * (BI, Roger, Óscar) y autorizaRecargaGas deja aprobar o rechazar (solo Vico). Se
+     * devuelve `puedeResolver` para que la vista muestre u oculte los botones, aunque la
+     * validación real se repite en el servidor al resolver.
+     */
+    if ($accion == 'consultarSolicitudesGas') {
+        $noEmpSol = $_COOKIE['noEmpleado'] ?? 0;
+        if (!tieneAccesoEspecial($conn, $noEmpSol, 'verSolicitudesGas')) {
+            echo json_encode(['status' => 'error', 'message' => 'No tienes acceso a esta vista.']);
+            exit;
+        }
+
+        // usuarios.id_usuario no es único: se empareja con la fila de mayor id para que
+        // el JOIN no multiplique las solicitudes.
+        $sql = "SELECT s.id, s.id_vehiculo, s.saldo_solicitud, s.km_actual, s.km_recorrido,
+                       s.estatus, s.fecha, DATE(s.fecha) AS fecha_dia,
+                       s.fecha_resuelto, s.notas_resolucion,
+                       inv.placa, inv.marca, inv.modelo,
+                       IFNULL(NULLIF(TRIM(CONCAT(IFNULL(rrhh.nombres,''),' ',IFNULL(rrhh.apellidos,''))),''), u.nombre) AS solicitante,
+                       ur.nombre AS resolvio
+                FROM solicitudes_gas s
+                LEFT JOIN inventario inv ON inv.id_vehiculo = s.id_vehiculo
+                LEFT JOIN usuarios u  ON u.id  = (SELECT MAX(u2.id) FROM usuarios u2 WHERE u2.id_usuario = s.id_usuario)
+                LEFT JOIN usuarios ur ON ur.id = (SELECT MAX(u3.id) FROM usuarios u3 WHERE u3.id_usuario = s.id_resuelve)
+                LEFT JOIN mess_rrhh.usuarios rrhh ON rrhh.noEmpleado = u.noEmpleado
+                ORDER BY FIELD(s.estatus,'PENDIENTE','APROBADA','RECHAZADA'), s.fecha DESC";
+
+        $res = $conn->query($sql);
+        $solicitudes = [];
+        if ($res) { while ($row = $res->fetch_assoc()) $solicitudes[] = $row; }
+
+        echo json_encode([
+            'status'        => 'success',
+            'puedeResolver' => tieneAccesoEspecial($conn, $noEmpSol, 'autorizaRecargaGas'),
+            'solicitudes'   => $solicitudes
+        ]);
+        exit;
+    }
+
+    /** Aprobar o rechazar una solicitud. Solo con autorizaRecargaGas. */
+    if ($accion == 'resolverSolicitudGas') {
+        $noEmpRes = $_COOKIE['noEmpleado'] ?? 0;
+        if (!tieneAccesoEspecial($conn, $noEmpRes, 'autorizaRecargaGas')) {
+            echo json_encode(['status' => 'error', 'message' => 'No tienes permiso para resolver solicitudes.']);
+            exit;
+        }
+
+        $idSol      = intval($_POST['id_solicitud'] ?? 0);
+        $resolucion = strtoupper(trim($_POST['resolucion'] ?? ''));
+        $notas      = trim($_POST['notas'] ?? '');
+
+        if ($idSol <= 0 || !in_array($resolucion, ['APROBADA', 'RECHAZADA'], true)) {
+            echo json_encode(['status' => 'error', 'message' => 'Datos incompletos.']);
+            exit;
+        }
+
+        // Solo se resuelve lo que sigue pendiente: evita que dos personas la cambien dos
+        // veces, o que se reabra algo ya resuelto.
+        $idResuelve = intval($_COOKIE['id_usuario'] ?? 0);
+        $stmt = $conn->prepare(
+            "UPDATE solicitudes_gas
+                SET estatus = ?, id_resuelve = ?, fecha_resuelto = NOW(), notas_resolucion = ?
+              WHERE id = ? AND estatus = 'PENDIENTE'"
+        );
+        $stmt->bind_param("sisi", $resolucion, $idResuelve, $notas, $idSol);
+        $stmt->execute();
+        $cambio = $stmt->affected_rows > 0;
+        $stmt->close();
+
+        if (!$cambio) {
+            echo json_encode(['status' => 'error', 'message' => 'La solicitud ya fue resuelta o no existe.']);
+            exit;
+        }
+
+        // El aviso al solicitante no debe tumbar la resolución: si el correo falla, la
+        // solicitud ya quedó resuelta igual.
+        $avisado = false;
+        try {
+            require_once __DIR__ . '/includes/enviar_notificacion.php';
+            $q = $conn->prepare(
+                "SELECT s.saldo_solicitud, s.notas_resolucion, inv.placa, inv.marca, inv.modelo,
+                        u.nombre AS nombre_sol, u.correo AS correo_sol
+                 FROM solicitudes_gas s
+                 LEFT JOIN inventario inv ON inv.id_vehiculo = s.id_vehiculo
+                 LEFT JOIN usuarios u ON u.id = (SELECT MAX(u2.id) FROM usuarios u2 WHERE u2.id_usuario = s.id_usuario)
+                 WHERE s.id = ? LIMIT 1"
+            );
+            $q->bind_param("i", $idSol);
+            $q->execute();
+            $d = $q->get_result()->fetch_assoc();
+            $q->close();
+
+            if ($d && !empty($d['correo_sol'])) {
+                $aprobada = ($resolucion === 'APROBADA');
+                $esc = fn($v) => htmlspecialchars((string)($v ?? ''), ENT_QUOTES, 'UTF-8');
+                $vehiculo = trim($d['marca'] . ' ' . $d['modelo']) . ' — ' . $d['placa'];
+                $contenido = '<h2>Hola ' . $esc($d['nombre_sol']) . ',</h2>'
+                    . '<h3 style="font-weight:normal">Tu solicitud de reposición de crédito de gasolina fue <b>'
+                    . ($aprobada ? 'aprobada' : 'rechazada') . '</b>.</h3>'
+                    . '<table style="margin:0 auto; font-size:15px; line-height:1.6">'
+                    . '<tr><td align="right"><b>Vehículo:</b></td><td align="left">' . $esc($vehiculo) . '</td></tr>'
+                    . ($notas !== '' ? '<tr><td align="right"><b>Notas:</b></td><td align="left">' . $esc($notas) . '</td></tr>' : '')
+                    . '</table>';
+
+                $r = enviarCorreoMess(
+                    [$d['correo_sol']],
+                    ($aprobada ? 'Recarga de gasolina aprobada' : 'Recarga de gasolina rechazada') . ' — Control Vehicular',
+                    plantillaCorreoMess(
+                        $aprobada ? 'Recarga aprobada' : 'Recarga rechazada',
+                        $aprobada ? 'rgb(29, 179, 47)' : 'rgb(200, 45, 45)',
+                        $contenido
+                    )
+                );
+                $avisado = $r['ok'];
+            }
+        } catch (Throwable $e) {
+            error_log("Fallo al notificar resolución de recarga $idSol: " . $e->getMessage());
+        }
+
+        echo json_encode(['status' => 'success', 'notificado' => $avisado]);
         exit;
     }
 

--- a/checkVehiculo.php
+++ b/checkVehiculo.php
@@ -57,7 +57,8 @@ if ($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null) {
                 ?>
 
                 <!-- Begin Page Content -->
-                <div class="container-fluid">                    
+                <div class="container-fluid">
+                    <h1 class="h3 mb-3 text-black-800">Checklist de Vehículo</h1>
                     <div class="row" name="DivVehiculosAsignados" id="DivVehiculosAsignados">
                         <div class="col-xl-12 col-lg-12 col-md-1 col-sm-12 col-12">
                             <table id="TVehiculosAsignados" name="TVehiculosAsignados" class="table table-striped table-bordered">
@@ -118,9 +119,12 @@ if ($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null) {
                             </div>
                         </div>
                         <div class="d-flex justify-content-end mb-3">
+                            <!-- Aquí había un segundo par de botones (btnguardarCheck2 /
+                                 btnGuardarAvance2) que repetía los del pie del asistente, con
+                                 etiquetas distintas para la misma acción ("Registrar avance"
+                                 arriba, "Guardar avance" abajo). Se dejan solo los del pie,
+                                 que es donde está la navegación entre pasos. -->
                             <button type="button" class="btn btn-primary btn-sm mr-1" onclick="MostrarDivVehiculosAsignados()"><i class="fas fa-exchange-alt mr-1"></i>Cambiar de vehículo</button>
-                            <button type="button" id="btnguardarCheck2" name="btnguardarCheck2" class="btn btn-success btn-sm mr-1" onclick="guardarCheckIn()" style="display:none;">Guardar</button>
-                            <button type="button" id="btnGuardarAvance2" name="btnGuardarAvance2" class="btn btn-warning btn-sm" onclick="guardarAvance()">Registrar avance</button>
                         </div>
                         <input type="hidden" id="marca" name="marca">
                         <input type="hidden" id="modelo" name="modelo">
@@ -161,8 +165,17 @@ if ($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null) {
                         flex-shrink: 0;
                     }
                     .chk-dot:hover { transform: scale(1.15); }
-                    .chk-dot.active { background: var(--accent); color: #fff; border-color: var(--accent-dark); }
                     .chk-dot.filled { background: #1cc88a; color: #fff; border-color: #17a673; }
+                    /* Amarillo: el apartado tiene datos capturados pero le falta la foto.
+                       Antes solo había verde (con foto) y gris (sin nada), así que un
+                       apartado a medio llenar se veía igual que uno sin tocar. */
+                    .chk-dot.parcial { background: #f6c23e; color: #6b4c00; border-color: #dda20a; }
+                    /* .active va al FINAL y con doble clase a propósito: marca en qué paso
+                       estás y debe ganarle al color de estado. Declarada antes, el verde y
+                       el amarillo la tapaban y se perdía el "aquí estás". */
+                    .chk-dot.active,
+                    .chk-dot.active.filled,
+                    .chk-dot.active.parcial { background: var(--accent); color: #fff; border-color: var(--accent-dark); }
                     .chk-foto-area { display: flex; flex-direction: column; align-items: center; }
                     .chk-foto-preview { max-width: 180px; max-height: 140px; border-radius: 8px; margin-top: 6px; display: none; }
                 </style>
@@ -383,7 +396,9 @@ if ($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null) {
                                     '<i class="fas fa-car fa-1x"></i><b> ' + Registro.placa + ' </b>',
                                     '<b> ' + Registro.modelo + ' </b>',
                                     asignado,
-                                    '<div class="text-center"><button type="button" class="btn btn-sm btn-success" onclick=\'SeleccionaVehiculo(' + JSON.stringify(Registro) + ')\'><i class="fas fa-check fa-1x"></i></button></div>'
+                                    // Antes era solo un ✔ sin texto: no se entendía que ese
+                                    // botón abre el checklist del vehículo.
+                                    '<div class="text-center"><button type="button" class="btn btn-sm btn-success" onclick=\'SeleccionaVehiculo(' + JSON.stringify(Registro) + ')\'><i class="fas fa-clipboard-check mr-1"></i>Registrar</button></div>'
                                 ]).draw(false);
                             });
 
@@ -419,7 +434,11 @@ if ($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null) {
             $('#fotoVehiculoPlaceholder').show();
         }
 
-        limpiarRutasFoto();
+        // Limpieza completa: si no, al cambiar de vehículo se quedaban las fotos y los
+        // datos capturados del anterior.
+        idChecklistActual = 0;
+        forzarChecklistNuevo = false;
+        limpiarFormularioChecklist();
         OcultaDivVehiculosAsignados();
         verificarBorrador(Registro.idCoche);
         verificarCompletitud();
@@ -469,12 +488,16 @@ if ($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null) {
             // Agregar opción al FormData
             formData.append('opcion', 'guardarCheckIn');
             formData.append('estatus', 'completo');
+            // Identifica el checklist destino: evita que el servidor adivine "el último
+            // borrador del vehículo" y acabe escribiendo en otro.
+            if (idChecklistActual > 0) formData.append('id_checklist', idChecklistActual);
+            if (forzarChecklistNuevo)  formData.append('nuevo', '1');
 
             // Deshabilitar botones para evitar múltiples envíos
             $('#btnguardarCheck').prop('disabled', true);
-            $('#btnguardarCheck2').prop('disabled', true);
+            
             $('#btnGuardarAvance').prop('disabled', true);
-            $('#btnGuardarAvance2').prop('disabled', true);
+            
             
             // Mostrar mensaje de procesamiento
             Swal.fire({
@@ -502,21 +525,28 @@ if ($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null) {
                         window.location.assign("verifica_checkinVehiculo");
                     } else {
                         Swal.fire("Error", "Hubo un problema al guardar el check-in. Inténtalo nuevamente.", "error");
-                        $('#btnguardarCheck, #btnguardarCheck2, #btnGuardarAvance, #btnGuardarAvance2').prop('disabled', false);
+                        $('#btnguardarCheck, #btnGuardarAvance').prop('disabled', false);
                         verificarCompletitud();
                     }
                 },
                 error: function(jqXHR, textStatus, errorThrown) {
                     Swal.close();
                     Swal.fire("Error", "No se pudo completar la solicitud. Por favor, inténtalo más tarde.", "error");
-                    $('#btnguardarCheck, #btnguardarCheck2, #btnGuardarAvance, #btnGuardarAvance2').prop('disabled', false);
+                    $('#btnguardarCheck, #btnGuardarAvance').prop('disabled', false);
                     verificarCompletitud();
                 }
             });
             
         }
 
-        function guardarAvance() {
+        /**
+         * Guarda el avance del checklist.
+         *
+         * @param {boolean} silencioso  true cuando lo dispara el cambio de apartado:
+         *        no bloquea con el modal de carga ni muestra el "Avance guardado", que
+         *        en cada paso sería insoportable. Solo avisa si algo falla.
+         */
+        function guardarAvance(silencioso) {
             let formData = new FormData();
 
             $('input[type="text"], input[type="date"], input[type="input"], input[type="hidden"]').each(function () {
@@ -536,27 +566,40 @@ if ($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null) {
             $('textarea').each(function () {
                 formData.append($(this).attr('name'), $(this).val());
             });
+            // Cada foto se envía UNA sola vez. getFotoInfo() en AccionesCheckVehiculo.php
+            // renombra el archivo con la hora de subida, así que reenviarlo en cada
+            // guardado dejaría una copia distinta en disco por cada paso. Y no hace falta:
+            // cuando no llega archivo, el servidor CONSERVA la ruta que ya tenía
+            // (upsertChecklistSeccion), así que la foto guardada no se pierde ni se
+            // sustituye. Solo se vuelve a mandar si el usuario elige otra imagen, que es
+            // cuando se borra la marca (ver el listener de change de los input file).
+            var enviadasAhora = [];
             $('input[type="file"]').each(function () {
-                if ($(this)[0].files.length > 0) {
-                    formData.append($(this).attr('name'), $(this)[0].files[0]);
+                var nombre = $(this).attr('name');
+                if ($(this)[0].files.length > 0 && !fotosEnviadas.has(nombre)) {
+                    formData.append(nombre, $(this)[0].files[0]);
+                    enviadasAhora.push(nombre);
                 }
             });
 
             formData.append('opcion', 'guardarCheckIn');
             formData.append('estatus', 'borrador');
+            // Identifica el checklist destino (ver comentario en guardarCheckIn).
+            if (idChecklistActual > 0) formData.append('id_checklist', idChecklistActual);
+            if (forzarChecklistNuevo)  formData.append('nuevo', '1');
 
             $('#btnguardarCheck').prop('disabled', true);
-            $('#btnguardarCheck2').prop('disabled', true);
             $('#btnGuardarAvance').prop('disabled', true);
-            $('#btnGuardarAvance2').prop('disabled', true);
 
-            Swal.fire({
-                title: "Guardando avance...",
-                text: "Se está guardando tu progreso.",
-                allowOutsideClick: false,
-                allowEscapeKey: false,
-                didOpen: () => { Swal.showLoading(); }
-            });
+            if (!silencioso) {
+                Swal.fire({
+                    title: "Guardando avance...",
+                    text: "Se está guardando tu progreso.",
+                    allowOutsideClick: false,
+                    allowEscapeKey: false,
+                    didOpen: () => { Swal.showLoading(); }
+                });
+            }
 
             $.ajax({
                 url: 'AccionesCheckVehiculo.php',
@@ -566,25 +609,82 @@ if ($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null) {
                 contentType: false,
                 dataType: 'json',
                 success: function(response) {
-                    Swal.close();
+                    if (!silencioso) Swal.close();
+                    $('#btnGuardarAvance').prop('disabled', false);
+
                     if (response.success) {
-                        Swal.fire("Avance guardado", "Tu progreso fue guardado. Puedes continuar el registro más tarde.", "success").then(function() {
-                            $('#btnGuardarAvance, #btnGuardarAvance2').prop('disabled', false);
+                        // A partir de aquí ya se sabe en qué checklist se trabaja: los
+                        // siguientes guardados lo reenvían y dejan de depender de que el
+                        // servidor adivine cuál es.
+                        if (response.id_checklist) {
+                            idChecklistActual = parseInt(response.id_checklist, 10) || 0;
+                            forzarChecklistNuevo = false;
+                        }
+
+                        // Ya están en el servidor: no volver a subirlas en los siguientes
+                        // guardados. Si el usuario cambia la imagen, el listener de change
+                        // quita la marca y vuelve a viajar.
+                        enviadasAhora.forEach(function (n) { fotosEnviadas.add(n); });
+                        // En silencioso no se confirma nada: el usuario ya está en el
+                        // siguiente apartado y un modal ahí solo estorbaría.
+                        if (!silencioso) {
+                            Swal.fire("Avance guardado", "Tu progreso fue guardado. Puedes continuar el registro más tarde.", "success").then(verificarCompletitud);
+                        } else {
                             verificarCompletitud();
-                        });
+                        }
                     } else {
+                        // El error sí se avisa siempre: si no se guardó, el usuario tiene
+                        // que enterarse aunque el guardado fuera automático.
                         Swal.fire("Error", "Hubo un problema al guardar el avance.", "error");
-                        $('#btnGuardarAvance, #btnGuardarAvance2').prop('disabled', false);
                         verificarCompletitud();
                     }
                 },
                 error: function() {
-                    Swal.close();
+                    if (!silencioso) Swal.close();
                     Swal.fire("Error", "No se pudo completar la solicitud.", "error");
-                    $('#btnGuardarAvance, #btnGuardarAvance2').prop('disabled', false);
+                    $('#btnGuardarAvance').prop('disabled', false);
                     verificarCompletitud();
                 }
             });
+        }
+
+        /**
+         * Deja el formulario del checklist como recién abierto.
+         *
+         * limpiarRutasFoto() solo vaciaba los campos ruta_foto_*, pero NO quitaba las
+         * miniaturas que inserta setRuta() (.foto-borrador-preview) ni los datos ya
+         * capturados. Por eso, al empezar un checklist nuevo o al cambiar de vehículo,
+         * seguían viéndose las fotos y los valores del anterior.
+         *
+         * Se limpia solo el contenido de los pasos (.chk-slide): fuera de ahí están los
+         * campos ocultos del vehículo (id_coche, placa, marca...), que deben conservarse.
+         */
+        // Chrome restaura los valores de los inputs al volver a una página (bfcache /
+        // restauración de sesión), y lo hace DESPUÉS de que corra la limpieza. Con
+        // autocomplete=off deja de hacerlo, así que un checklist nuevo no aparece con los
+        // datos del anterior.
+        $(function () {
+            $('.chk-slide').find('input, textarea, select').attr('autocomplete', 'off');
+        });
+
+        function limpiarFormularioChecklist() {
+            limpiarRutasFoto();
+
+            // Miniaturas del borrador y previsualizaciones de fotos recién tomadas
+            $('.foto-borrador-preview').remove();
+            $('[id^="preview_foto_"]').attr('src', '');
+            $('[id^="wrap_foto_"]').hide();
+            $('[id^="captura_foto_"]').show();
+
+            $('.chk-slide').find('input[type="file"]').val('');
+            $('.chk-slide').find('input[type="text"], input[type="date"], input[type="number"], textarea').val('');
+            $('.chk-slide').find('select').prop('selectedIndex', 0);
+            $('.chk-slide').find('input[type="checkbox"]').prop('checked', false);
+
+            // Ninguna foto de esta sesión sigue vigente para el checklist nuevo.
+            fotosEnviadas.clear();
+
+            verificarCompletitud();
         }
 
         function limpiarRutasFoto() {
@@ -608,7 +708,17 @@ if ($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null) {
                             cancelButtonText: 'No, empezar de nuevo'
                         }).then(function(result) {
                             if (result.isConfirmed) {
+                                // Continuar el borrador existente: se trabaja sobre él.
+                                idChecklistActual = parseInt(response.id_checklist, 10) || 0;
+                                forzarChecklistNuevo = false;
                                 cargarDatosBorrador(response);
+                            } else {
+                                // Empezar de cero. Antes esto no hacía NADA: ni vaciaba el
+                                // formulario ni creaba un checklist nuevo, así que se veían
+                                // los datos del anterior y el guardado terminaba pisándolo.
+                                idChecklistActual = 0;
+                                forzarChecklistNuevo = true;
+                                limpiarFormularioChecklist();
                             }
                         });
                     }
@@ -816,8 +926,19 @@ if ($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null) {
         var pasoActual = 0;
         var totalPasos = <?= $totalPasos ?>;
 
-        function irAPaso(n) {
+        function irAPaso(n, sinGuardar) {
             if (n < 0 || n >= totalPasos) return;
+
+            // El avance se guarda solo al cambiar de apartado, que era el acuerdo: el
+            // usuario llenaba una sección, se movía y perdía lo capturado si no se
+            // acordaba de pulsar el botón. Se guarda en silencio (sin el modal de
+            // "Guardando avance...") para no interrumpir la navegación.
+            // sinGuardar = true en las llamadas que no son navegación del usuario:
+            // el arranque en el paso 0 y el salto a la sección con fotos faltantes.
+            if (!sinGuardar && n !== pasoActual && typeof guardarAvance === 'function') {
+                guardarAvance(true);
+            }
+
             pasoActual = n;
             document.getElementById('chkTrack').style.transform = 'translateX(-' + (pasoActual * 100) + '%)';
             document.getElementById('pasoInfo').textContent = 'Paso ' + (pasoActual + 1) + ' de ' + totalPasos;
@@ -868,14 +989,54 @@ if ($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null) {
             return faltantes;
         }
 
+        /**
+         * ¿El apartado tiene algo capturado, aunque le falte la foto?
+         *
+         * Se mira el contenido real del slide: texto, fechas, observaciones, selects y
+         * casillas marcadas. Sirve para distinguir un apartado a medio llenar de uno
+         * que nadie ha tocado, que antes se veían igual (los dos grises).
+         */
+        // Fotos que ya viajaron al servidor en esta sesión de captura. Evita reenviar el
+        // mismo archivo en cada guardado, que crearía una copia nueva en disco cada vez.
+        var fotosEnviadas = new Set();
+
+        // Checklist sobre el que se está trabajando. El servidor lo devuelve al guardar y
+        // se reenvía en los guardados siguientes; así se escribe siempre en el mismo, en
+        // lugar de que el servidor adivine "el último borrador del vehículo" y acabe
+        // sobrescribiendo otro.
+        var idChecklistActual = 0;
+        // true cuando el usuario eligió "No, empezar de nuevo": el primer guardado debe
+        // crear un checklist nuevo en vez de continuar el borrador existente.
+        var forzarChecklistNuevo = false;
+
+        function pasoTieneDatos(idx) {
+            var slide = document.querySelectorAll('.chk-slide')[idx];
+            if (!slide) return false;
+
+            var conDato = false;
+            slide.querySelectorAll('input[type="text"], input[type="date"], input[type="number"], textarea, select').forEach(function(el) {
+                if (String(el.value || '').trim() !== '') conDato = true;
+            });
+            if (!conDato) {
+                slide.querySelectorAll('input[type="checkbox"]').forEach(function(el) {
+                    if (el.checked) conDato = true;
+                });
+            }
+            return conDato;
+        }
+
         function verificarCompletitud() {
             var inputs = document.querySelectorAll('input[type="file"][name^="foto_"]');
             var dots = document.querySelectorAll('.chk-dot');
             inputs.forEach(function(input, idx) {
-                // Sincroniza el verde con el estado real: verde SOLO si el apartado
-                // tiene foto. Antes solo agregaba (marcarDotLleno) y nunca quitaba, por
-                // eso al borrar una foto el punto seguía marcado verde como completo.
-                if (dots[idx]) dots[idx].classList.toggle('filled', pasoTieneFoto(idx));
+                // Tres estados: verde = con foto (completo), amarillo = capturado pero
+                // sin foto, gris = sin tocar.
+                // El verde se sincroniza en ambos sentidos: antes solo se agregaba y
+                // nunca se quitaba, así que al borrar una foto el punto seguía en verde.
+                var tieneFoto = pasoTieneFoto(idx);
+                if (!dots[idx]) return;
+                dots[idx].classList.toggle('filled', tieneFoto);
+                dots[idx].classList.toggle('parcial', !tieneFoto && pasoTieneDatos(idx));
             });
         }
 
@@ -897,20 +1058,22 @@ if ($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null) {
                 cancelButtonText: 'Guardar avance'
             }).then(function(result) {
                 if (result.isConfirmed) {
-                    irAPaso(faltantes[0].idx);
+                    irAPaso(faltantes[0].idx, true);   // salto guiado, no es navegacion del usuario
                 } else if (result.dismiss === Swal.DismissReason.cancel) {
                     guardarAvance();
                 }
             });
         }
 
-        $(document).on('input', 'textarea, input[type="text"], input[type="date"]', verificarCompletitud);
-        $(document).on('change', 'input[type="checkbox"]', verificarCompletitud);
+        // Se añaden number y select para que el amarillo (capturado sin foto) también
+        // reaccione a esos campos; pasoTieneDatos() los mira.
+        $(document).on('input', 'textarea, input[type="text"], input[type="date"], input[type="number"]', verificarCompletitud);
+        $(document).on('change', 'input[type="checkbox"], select', verificarCompletitud);
 
         function OcultaDivVehiculosAsignados() {
             $('#DivVehiculosAsignados').hide();
             $('#DivBtnVehiculosAsignados').show();
-            irAPaso(0);
+            irAPaso(0, true);   // arranque: no hay nada que guardar todavia
         }
         function MostrarDivVehiculosAsignados() {
             $('#DivBtnVehiculosAsignados').hide();
@@ -921,6 +1084,9 @@ if ($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null) {
             var input = this;
             var file = input.files[0];
             if (!file) return;
+            // Imagen nueva para este apartado: se quita la marca para que vuelva a
+            // subirse y sustituya a la anterior en el servidor.
+            fotosEnviadas.delete(input.name);
             var id = input.name.replace('foto_', '');
             var preview = document.getElementById('preview_foto_' + id);
             var captura = document.getElementById('captura_foto_' + id);
@@ -943,8 +1109,14 @@ if ($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null) {
             var wrap = document.getElementById('wrap_foto_' + id);
             var preview = document.getElementById('preview_foto_' + id);
             var ruta = document.querySelector('input[name="ruta_foto_' + id + '"]');
-            if (input) input.value = '';
-            if (ruta) ruta.value = '';
+            if (input) {
+                input.value = '';
+                fotosEnviadas.delete(input.name);
+            }
+            // Centinela, no cadena vacía: el servidor conserva la foto guardada cuando no
+            // recibe archivo ni ruta (para que un guardado parcial no la borre), así que
+            // hace falta una señal explícita de "esta sí quiero quitarla".
+            if (ruta) ruta.value = '__BORRAR__';
             if (preview) preview.src = '';
             if (wrap) wrap.style.display = 'none';
             if (captura) captura.style.display = '';

--- a/importar_reportes.php
+++ b/importar_reportes.php
@@ -49,6 +49,7 @@ if (empty($_COOKIE['noEmpleado'])) {
                 <?php include 'encabezado.php'; ?>
 
                 <div class="container-fluid pb-4" style="max-width: 820px;">
+                    <h1 class="h3 mb-3 text-black-800">Importar Reportes</h1>
 
                     <!-- Bloqueo por acceso -->
                     <div id="loadingAcceso" class="text-center py-5">

--- a/inicio.php
+++ b/inicio.php
@@ -71,8 +71,27 @@ if ($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null) {
                         <div class="col-12 mb-3">
                             <div id="vehiculosAsignados" name="vehiculosAsignados"></div>
                         </div>
+                        <!-- El manual iba embebido con <embed> a 650px de alto: cargaba el
+                             PDF completo en cada visita al inicio y en móvil se veía mal.
+                             Ahora es un botón de descarga. -->
                         <div class="col-xl-12 col-lg-12">
-                            <embed id="vistaPrevia" src='img/Manual Control Vehicular.pdf' type="application/pdf" width="100%" height="650">
+                            <div class="card shadow-sm">
+                                <div class="card-body d-flex align-items-center flex-wrap gap-3">
+                                    <i class="fas fa-file-pdf fa-2x text-danger"></i>
+                                    <div class="flex-grow-1">
+                                        <div class="fw-bold">Manual de usuario</div>
+                                        <div class="small text-muted">Guía de uso del sistema de Control Vehicular.</div>
+                                    </div>
+                                    <a href="img/Manual Control Vehicular.pdf" download
+                                       class="btn btn-primary btn-sm">
+                                        <i class="fas fa-download me-1"></i> Descargar
+                                    </a>
+                                    <a href="img/Manual Control Vehicular.pdf" target="_blank" rel="noopener"
+                                       class="btn btn-outline-secondary btn-sm">
+                                        <i class="fas fa-up-right-from-square me-1"></i> Abrir
+                                    </a>
+                                </div>
+                            </div>
                         </div>
                     </div>
 

--- a/js/global/vehiculos.js
+++ b/js/global/vehiculos.js
@@ -203,23 +203,12 @@ function evaluarValidaciones(data) {
         if (subareas[k] === 'ok') ok++;
     });
 
-    // Mantenimiento (3 items: autorizado, sin pendientes, próximo al día).
-    // Misma semántica que renderListaMantenimiento: REALIZADO cuenta como autorizado
-    // y "sin fecha_proxi tras un REALIZADO" cuenta como al día.
-    var mt = data.mantenimiento || null;
-    total += 3;
-    if (mt) {
-        var vobo = (mt.VoBo_jefe || '').toUpperCase();
-        var realizado = (vobo === 'REALIZADO');
-        if (vobo === 'AUTORIZADO' || realizado) ok++;
-        if (vobo && vobo !== 'PENDIENTE') ok++;
-        if (mt.fecha_proxi) {
-            var prox = new Date(mt.fecha_proxi);
-            if (!isNaN(prox.getTime()) && prox >= new Date()) ok++;
-        } else if (realizado) {
-            ok++;
-        }
-    }
+    // Mantenimiento excluido del semáforo por decisión de negocio: la tarjeta es solo
+    // INFORMATIVA. Un mantenimiento pendiente o sin fecha próxima no es un incumplimiento
+    // del usuario del vehículo, así que no debe bajarle el semáforo.
+    //
+    // messbook (loginMaster/inicio.php) ya lo excluía; aquí seguía sumando 3 items, así
+    // que el mismo vehículo daba semáforos distintos según dónde se mirara.
 
     return { ok: ok, total: total };
 }

--- a/menu.php
+++ b/menu.php
@@ -26,6 +26,7 @@
     // necesariamente ve todos los vehículos. Un permiso propio permitiría concederlo
     // sin el otro, que no tiene sentido.
     $puedeVerCheckins   = !empty($accesos['verTodosVehiculo']);
+    $puedeVerRecargas   = !empty($accesos['verSolicitudesGas']);
     $muestraAdmin       = $puedeVerQR || $puedeCargarReportes;
 
     // Página activa para resaltar el item del menú
@@ -74,6 +75,13 @@
         </a>
     </li>
 
+    <li class="nav-item<?= menuActivo('seguimiento_anomalias', $paginaActual) ?>">
+        <a class="nav-link py-2" href="seguimiento_anomalias">
+            <i class="fas fa-fw fa-triangle-exclamation"></i>
+            <span>Hist. Anomalías</span>
+        </a>
+    </li>
+
     <li class="nav-item<?= menuActivo('seguimiento_siniestro', $paginaActual) ?>">
         <a class="nav-link py-2" href="seguimiento_siniestro">
             <i class="fas fa-fw fa-car-crash"></i>
@@ -90,6 +98,15 @@
             <span>Historial de Cargas</span>
         </a>
     </li>
+
+    <?php if ($puedeVerRecargas): ?>
+    <li class="nav-item<?= menuActivo('validar_recargas', $paginaActual) ?>">
+        <a class="nav-link py-2" href="validar_recargas">
+            <i class="fas fa-fw fa-credit-card"></i>
+            <span>Recargas de Gas</span>
+        </a>
+    </li>
+    <?php endif; ?>
 
     <?php if ($puedeVerCheckins): ?>
     <!-- Check-ins de TODOS los vehículos. Va con verTodosVehiculo: ver los check-in de

--- a/prestamos.php
+++ b/prestamos.php
@@ -41,7 +41,8 @@
                 ?>
                 
                 <!-- Begin Page Content -->
-                <div class="container-fluid">    
+                <div class="container-fluid">
+                    <h1 class="h3 mb-3 text-black-800">Solicitar Préstamo</h1>
                     <div class="card shadow-sm border-0">
                         <div class="card-header text-bg-secondary">
                             Solicitud de Préstamo Vehicular
@@ -184,7 +185,7 @@
         function toggleDato() {
             var tipo = $("#visita_vinculada").val();
             var necesitaDato = ['OV', 'OT', 'Proyecto'].includes(tipo);
-            var labels = { OV: 'Número de OV', OT: 'Número de OT', Proyecto: 'Nombre del proyecto' };
+            var labels = { OV: 'Número de OV', OT: 'Número de OT', Proyecto: 'Número del proyecto' };
             if (necesitaDato) {
                 $("#labelDato").text(labels[tipo] || 'OV / Cliente / OT / Proyecto');
                 $("#colDato").show();

--- a/qr_vehiculo.php
+++ b/qr_vehiculo.php
@@ -574,12 +574,33 @@ if (empty($_COOKIE['noEmpleado'])) {
 
             $('#btnGuardarAnomalia').prop('disabled', true).html('<span class="spinner-border spinner-border-sm me-1"></span> Guardando...');
 
-            comprimirImagen(foto).then(function (fotoComprimida) {
+            // La ubicación se intenta obtener pero NO es obligatoria: si el GPS falla o
+            // tarda, la anomalía se registra igual sin coordenadas. A diferencia del
+            // check-in, aquí bloquear al usuario no aporta nada.
+            function obtenerCoordsOpcional() {
+                return new Promise(function (resolve) {
+                    if (!navigator.geolocation) { resolve(''); return; }
+                    navigator.geolocation.getCurrentPosition(
+                        function (pos) {
+                            resolve(pos.coords.latitude.toFixed(6) + ', ' + pos.coords.longitude.toFixed(6));
+                        },
+                        function (err) {
+                            console.warn('Anomalía sin coordenadas:', err && err.message);
+                            resolve('');
+                        },
+                        { enableHighAccuracy: true, timeout: 8000, maximumAge: 60000 }
+                    );
+                });
+            }
+
+            Promise.all([comprimirImagen(foto), obtenerCoordsOpcional()]).then(function (res) {
+            var fotoComprimida = res[0];
             var formData = new FormData();
             formData.append('accion', 'registrarAnomalia');
             formData.append('id_vehiculo', idVehiculo);
             formData.append('descripcion', descripcion);
             formData.append('foto', fotoComprimida, 'foto.jpg');
+            formData.append('coordenadas', res[1] || '');
 
             $.ajax({
                 url: 'acciones_anomalias.php',

--- a/seguimiento_anomalias.php
+++ b/seguimiento_anomalias.php
@@ -1,0 +1,298 @@
+<?php
+session_start();
+require_once __DIR__ . '/includes/sesion_cookies.php';
+include 'conn.php';
+if ($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null) {
+    echo '<script>window.location.assign("index")</script>';
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Control Vehicular - Anomalías</title>
+    <!-- MESS Design System -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
+    <link href="css/mess-ds.css" rel="stylesheet">
+</head>
+<body id="page-top">
+    <div id="wrapper">
+        <?php include 'menu.php'; ?>
+        <div id="content-wrapper" class="d-flex flex-column">
+            <div id="content">
+                <?php include 'encabezado.php'; ?>
+                <div class="container-fluid">
+
+                    <div class="d-sm-flex align-items-center justify-content-between mb-3">
+                        <h1 class="h3 mb-0 text-black-800">Historial de Anomalías</h1>
+                        <span class="badge bg-secondary fs-6" id="badgeTotal"></span>
+                    </div>
+
+                    <!-- Filtros: mismos que el historial de siniestros -->
+                    <div class="card shadow-sm mb-4">
+                        <div class="card-body py-3">
+                            <div class="row g-2 align-items-end">
+                                <div class="col-6 col-md-3">
+                                    <label for="fDesde" class="form-label mb-1 small fw-semibold">Desde</label>
+                                    <input type="date" class="form-control form-control-sm" id="fDesde">
+                                </div>
+                                <div class="col-6 col-md-3">
+                                    <label for="fHasta" class="form-label mb-1 small fw-semibold">Hasta</label>
+                                    <input type="date" class="form-control form-control-sm" id="fHasta">
+                                </div>
+                                <div class="col-12 col-md-4">
+                                    <label for="fVehiculo" class="form-label mb-1 small fw-semibold">Vehículo</label>
+                                    <select class="form-select form-select-sm" id="fVehiculo">
+                                        <option value="">Todos</option>
+                                    </select>
+                                </div>
+                                <div class="col-12 col-md-2 d-grid">
+                                    <button class="btn btn-outline-secondary btn-sm" id="btnLimpiarFiltros">
+                                        <i class="fas fa-eraser me-1"></i> Limpiar
+                                    </button>
+                                </div>
+                            </div>
+                            <div class="row g-2 mt-1">
+                                <div class="col-12">
+                                    <div class="input-group input-group-sm">
+                                        <span class="input-group-text bg-white border-end-0"><i class="fas fa-search text-muted"></i></span>
+                                        <input type="text" class="form-control border-start-0" id="buscadorFeed"
+                                               placeholder="Buscar por placa, usuario o descripción...">
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div id="feedAnomalias" class="row"></div>
+
+                    <div id="noResultados" class="text-center text-muted py-5" style="display:none;">
+                        <i class="fas fa-triangle-exclamation fa-3x mb-3 d-block"></i>
+                        <p class="mb-0">No se encontraron anomalías.</p>
+                    </div>
+                </div>
+            </div>
+            <footer class="sticky-footer bg-white">
+                <div class="container my-auto"><div class="copyright text-center my-auto">
+                    <span>Copyright &copy; MESS <?php echo date("Y"); ?></span>
+                </div></div>
+            </footer>
+        </div>
+    </div>
+
+    <a class="scroll-to-top rounded" href="#page-top"><i class="fas fa-angle-up"></i></a>
+
+    <!-- Mapa de la ubicación. Mismo criterio que en ver_checkins.php: se abre dentro de
+         la vista para no perder los filtros, con el embed de Google Maps (sin API key).
+         El iframe se rellena al abrir, no al pintar la lista. -->
+    <div class="modal fade" id="modalMapa" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-lg modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header py-2">
+                    <h6 class="modal-title" id="modalMapaTitulo">Ubicación de la anomalía</h6>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+                </div>
+                <div class="modal-body p-0">
+                    <iframe id="mapaFrame" src="" style="border:0; width:100%; height:60vh;"
+                            loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+                </div>
+                <div class="modal-footer py-2">
+                    <span class="small text-muted me-auto" id="modalMapaCoords"></span>
+                    <a id="modalMapaAbrir" href="#" target="_blank" rel="noopener" class="btn btn-sm btn-outline-primary">
+                        <i class="fas fa-up-right-from-square me-1"></i> Abrir en Google Maps
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Foto de la anomalía a tamaño completo -->
+    <div class="modal fade" id="modalFoto" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-lg modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header py-2">
+                    <h6 class="modal-title" id="modalFotoTitulo">Anomalía</h6>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+                </div>
+                <div class="modal-body text-center p-2">
+                    <img id="modalFotoImg" src="" alt="" style="max-width:100%; max-height:70vh; border-radius:8px;">
+                    <div id="modalFotoError" class="text-muted py-5" style="display:none;">
+                        <i class="fas fa-image fa-3x d-block mb-2"></i>
+                        No se pudo cargar la imagen.
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+<script>
+    function esc(s) { return $('<div>').text(s == null ? '' : s).html(); }
+
+    /** Marcador para cuando no hay foto o la ruta guardada ya no resuelve. */
+    function marcadorSinFoto() {
+        return '<div class="rounded me-3 bg-body-secondary d-flex flex-column align-items-center justify-content-center flex-shrink-0"'
+             + ' style="width:84px; height:84px;" title="Sin foto">'
+             + '<i class="fas fa-image text-muted"></i>'
+             + '<span class="text-muted" style="font-size:.65rem;">sin foto</span></div>';
+    }
+
+    function fmtFecha(f) {
+        if (!f) return '';
+        var p = String(f).split(/[- :]/);
+        return p[2] + '/' + p[1] + '/' + p[0] + (p[3] ? ' ' + p[3] + ':' + (p[4] || '00') : '');
+    }
+
+    /** Aplica los cuatro filtros sobre las tarjetas ya cargadas. */
+    function filtrarFeed() {
+        var busqueda = ($('#buscadorFeed').val() || '').toLowerCase().trim();
+        var desde    = $('#fDesde').val();
+        var hasta    = $('#fHasta').val();
+        var vehiculo = $('#fVehiculo').val();
+
+        var visibles = 0;
+        $('.feed-card').each(function () {
+            var $c = $(this), ok = true;
+
+            if (busqueda && String($c.data('busqueda') || '').indexOf(busqueda) === -1) ok = false;
+
+            // Las fechas se comparan como texto AAAA-MM-DD: en ese formato el orden
+            // alfabético coincide con el cronológico.
+            var fecha = String($c.data('fecha') || '');
+            if (ok && desde && (!fecha || fecha < desde)) ok = false;
+            if (ok && hasta && (!fecha || fecha > hasta)) ok = false;
+
+            if (ok && vehiculo && String($c.data('vehiculo')) !== String(vehiculo)) ok = false;
+
+            $c.toggle(ok);
+            if (ok) visibles++;
+        });
+
+        $('#noResultados').toggle(visibles === 0);
+        $('#badgeTotal').text(visibles + (visibles === 1 ? ' anomalía' : ' anomalías'));
+    }
+
+    /** Llena el selector con los vehículos que realmente aparecen en el feed. */
+    function llenarFiltroVehiculos(lista) {
+        var vistos = {}, $sel = $('#fVehiculo');
+        lista.forEach(function (a) {
+            if (!a.id_vehiculo || vistos[a.id_vehiculo]) return;
+            vistos[a.id_vehiculo] = true;
+            $sel.append($('<option>').val(a.id_vehiculo).text((a.placa || 'S/P') + ' - ' + (a.modelo || '')));
+        });
+    }
+
+    function renderFeed(items) {
+        var $cont = $('#feedAnomalias').empty();
+        if (!items.length) {
+            $('#noResultados').show();
+            $('#badgeTotal').text('0 anomalías');
+            return;
+        }
+        $('#noResultados').hide();
+        llenarFiltroVehiculos(items);
+
+        items.forEach(function (a) {
+            var desc = a.descripcion || '';
+            // La descripción se muestra COMPLETA: la tabla anomalias no guarda nada más
+            // (vehículo, usuario, descripción, foto y fecha), así que no hay vista de
+            // detalle donde leer el resto si se recortara.
+            var descHtml = desc ? esc(desc) : '<em class="text-muted">Sin descripción</em>';
+            var busqueda = ((a.placa || '') + ' ' + (a.nombre_usuario || '') + ' ' + desc).toLowerCase();
+
+            // Si la imagen no carga se sustituye por el mismo marcador que se usa cuando
+            // no hay foto. No se apunta a img/sin_foto.png (la convención del proyecto)
+            // porque ese archivo NO existe: el respaldo quedaba igual de roto.
+            var foto = a.foto_ruta
+                ? '<img src="' + esc(a.foto_ruta) + '" class="rounded me-3 anomalia-foto" style="width:84px; height:84px; object-fit:cover; cursor:pointer;"'
+                    + ' data-foto="' + esc(a.foto_ruta) + '" data-titulo="' + esc((a.placa || '') + ' · ' + fmtFecha(a.fecha)) + '"'
+                    + ' onerror="this.onerror=null; this.outerHTML=marcadorSinFoto();">'
+                : marcadorSinFoto();
+
+            $cont.append(
+                '<div class="col-lg-6 col-12 mb-3 feed-card" data-busqueda="' + esc(busqueda) + '"'
+                + ' data-fecha="' + esc(a.fecha_dia || '') + '" data-vehiculo="' + esc(a.id_vehiculo || '') + '">'
+                + '  <div class="card shadow-sm h-100 border-0"><div class="card-body d-flex">'
+                +      foto
+                + '    <div class="flex-grow-1 min-w-0">'
+                + '      <h5 class="mb-0 text-primary fw-bold"><i class="fas fa-car me-1"></i>' + esc(a.placa || 'S/P') + '</h5>'
+                + '      <small class="text-muted d-block">' + esc([a.marca, a.modelo, a.color].filter(Boolean).join(' · ')) + '</small>'
+                + '      <div class="small mt-2">' + descHtml + '</div>'
+                + '      <div class="small text-muted mt-2">'
+                + '        <i class="fas fa-user me-1"></i>' + esc(a.nombre_usuario || 'S/R')
+                + '        <span class="ms-3"><i class="fas fa-calendar me-1"></i>' + fmtFecha(a.fecha) + '</span>'
+                +          (a.coordenadas
+                              ? '        <button type="button" class="btn btn-link btn-sm p-0 ms-3 align-baseline btn-mapa"'
+                                + ' data-coords="' + esc(a.coordenadas) + '"'
+                                + ' data-titulo="' + esc((a.placa || '') + ' · ' + fmtFecha(a.fecha)) + '"'
+                                + ' title="' + esc(a.coordenadas) + '"><i class="fas fa-map-marker-alt me-1"></i>Ubicación</button>'
+                              : '')
+                + '      </div>'
+                + '    </div>'
+                + '  </div></div>'
+                + '</div>'
+            );
+        });
+    }
+
+    function cargar() {
+        $('#feedAnomalias').html('<div class="col-12 text-center py-5"><i class="fas fa-spinner fa-spin fa-2x text-primary"></i></div>');
+        $.ajax({
+            url: 'acciones_anomalias.php',
+            type: 'POST',
+            dataType: 'json',
+            data: { accion: 'obtenerFeedAnomalias' }
+        }).done(function (resp) {
+            // Array.isArray antes de iterar: las acciones_*.php devuelven un objeto de
+            // error cuando algo falla, y recorrerlo rompe en silencio.
+            renderFeed(Array.isArray(resp) ? resp : []);
+            filtrarFeed();
+        }).fail(function () {
+            $('#feedAnomalias').html('<div class="col-12 text-center text-danger py-5"><i class="fas fa-exclamation-circle fa-2x"></i><p class="mt-2">Error al cargar las anomalías.</p></div>');
+        });
+    }
+
+    $(document).ready(function () {
+        cargar();
+        $('#buscadorFeed').on('input', filtrarFeed);
+        $('#fDesde, #fHasta, #fVehiculo').on('change', filtrarFeed);
+        $('#btnLimpiarFiltros').on('click', function () {
+            $('#fDesde, #fHasta, #buscadorFeed').val('');
+            $('#fVehiculo').val('');
+            filtrarFeed();
+        });
+
+        $('#modalFotoImg').on('error', function () {
+            $(this).hide();
+            $('#modalFotoError').show();
+        });
+
+        $(document).on('click', '.btn-mapa', function () {
+            var coords = $(this).data('coords');
+            $('#mapaFrame').attr('src', 'https://maps.google.com/maps?q=' + encodeURIComponent(coords) + '&z=16&output=embed');
+            $('#modalMapaTitulo').text($(this).data('titulo') || 'Ubicación de la anomalía');
+            $('#modalMapaCoords').text(coords);
+            $('#modalMapaAbrir').attr('href', 'https://www.google.com/maps?q=' + encodeURIComponent(coords));
+            bootstrap.Modal.getOrCreateInstance(document.getElementById('modalMapa')).show();
+        });
+
+        // Se descarga el mapa al cerrar: si no, el iframe sigue vivo en segundo plano.
+        document.getElementById('modalMapa').addEventListener('hidden.bs.modal', function () {
+            $('#mapaFrame').attr('src', '');
+        });
+
+        $(document).on('click', '.anomalia-foto', function () {
+            $('#modalFotoError').hide();
+            $('#modalFotoImg').show().attr('src', $(this).data('foto'));
+            $('#modalFotoTitulo').text($(this).data('titulo') || 'Anomalía');
+            bootstrap.Modal.getOrCreateInstance(document.getElementById('modalFoto')).show();
+        });
+    });
+</script>
+</body>
+</html>

--- a/seguimiento_siniestro.php
+++ b/seguimiento_siniestro.php
@@ -33,12 +33,39 @@ if ($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null) {
                         <span class="badge bg-secondary fs-6" id="badgeTotal"></span>
                     </div>
 
-                    <!-- Buscador -->
-                    <div class="mb-4">
-                        <div class="input-group">
-                            <span class="input-group-text bg-white border-end-0"><i class="fas fa-search text-muted"></i></span>
-                            <input type="text" class="form-control border-start-0" id="buscadorFeed"
-                                   placeholder="Buscar por placa, lugar o descripción...">
+                    <!-- Filtros -->
+                    <div class="card shadow-sm mb-4">
+                        <div class="card-body py-3">
+                            <div class="row g-2 align-items-end">
+                                <div class="col-6 col-md-3">
+                                    <label for="fDesde" class="form-label mb-1 small fw-semibold">Desde</label>
+                                    <input type="date" class="form-control form-control-sm" id="fDesde">
+                                </div>
+                                <div class="col-6 col-md-3">
+                                    <label for="fHasta" class="form-label mb-1 small fw-semibold">Hasta</label>
+                                    <input type="date" class="form-control form-control-sm" id="fHasta">
+                                </div>
+                                <div class="col-12 col-md-4">
+                                    <label for="fVehiculo" class="form-label mb-1 small fw-semibold">Vehículo</label>
+                                    <select class="form-select form-select-sm" id="fVehiculo">
+                                        <option value="">Todos</option>
+                                    </select>
+                                </div>
+                                <div class="col-12 col-md-2 d-grid">
+                                    <button class="btn btn-outline-secondary btn-sm" id="btnLimpiarFiltros">
+                                        <i class="fas fa-eraser me-1"></i> Limpiar
+                                    </button>
+                                </div>
+                            </div>
+                            <div class="row g-2 mt-1">
+                                <div class="col-12">
+                                    <div class="input-group input-group-sm">
+                                        <span class="input-group-text bg-white border-end-0"><i class="fas fa-search text-muted"></i></span>
+                                        <input type="text" class="form-control border-start-0" id="buscadorFeed"
+                                               placeholder="Buscar por placa, lugar o descripción...">
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
 
@@ -94,8 +121,12 @@ if ($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null) {
         $(document).ready(function () {
             cargarFeed();
 
-            $('#buscadorFeed').on('input', function () {
-                filtrarFeed($(this).val().toLowerCase().trim());
+            $('#buscadorFeed').on('input', filtrarFeed);
+            $('#fDesde, #fHasta, #fVehiculo').on('change', filtrarFeed);
+            $('#btnLimpiarFiltros').on('click', function () {
+                $('#fDesde, #fHasta, #buscadorFeed').val('');
+                $('#fVehiculo').val('');
+                filtrarFeed();
             });
 
             document.getElementById('modalDetalleSiniestro').addEventListener('hidden.bs.modal', function () {
@@ -131,6 +162,7 @@ if ($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null) {
                 return;
             }
             $('#noResultados').hide();
+            llenarFiltroVehiculos(items);
 
             items.forEach(function (s) {
                 var desc = s.descripcion || '';
@@ -142,7 +174,8 @@ if ($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null) {
                 var busqueda = ((s.placa || '') + ' ' + (s.lugar || '') + ' ' + desc).toLowerCase();
 
                 var card = `
-                    <div class="col-lg-6 col-12 mb-3 feed-card" data-busqueda="${busqueda.replace(/"/g, '&quot;')}">
+                    <div class="col-lg-6 col-12 mb-3 feed-card" data-busqueda="${busqueda.replace(/"/g, '&quot;')}"
+                         data-fecha="${fechaDisplay}" data-vehiculo="${s.id_vehiculo || ''}">
                         <div class="card shadow-sm h-100 border-0">
                             <div class="card-body">
                                 <div class="d-flex justify-content-between align-items-start mb-2">
@@ -176,19 +209,57 @@ if ($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null) {
             });
         }
 
-        function filtrarFeed(busqueda) {
-            if (!busqueda) {
-                $('.feed-card').show();
-                $('#noResultados').hide();
-                return;
-            }
+        /**
+         * Aplica los cuatro filtros a la vez sobre las tarjetas ya cargadas.
+         *
+         * Antes solo existía el buscador de texto. Las fechas se comparan como cadena
+         * "AAAA-MM-DD", que en ese formato ordena igual que cronológicamente, así que no
+         * hace falta convertir a Date.
+         */
+        /** Marcador para cuando una foto no carga (la ruta guardada ya no resuelve). */
+        function marcadorSinFoto() {
+            return '<div class="d-flex flex-column align-items-center justify-content-center bg-body-secondary text-muted"'
+                 + ' style="height:280px;" title="Sin foto">'
+                 + '<i class="fas fa-image fa-2x mb-2"></i><span class="small">No se pudo cargar la imagen</span></div>';
+        }
+
+        function filtrarFeed() {
+            var busqueda = ($('#buscadorFeed').val() || '').toLowerCase().trim();
+            var desde    = $('#fDesde').val();
+            var hasta    = $('#fHasta').val();
+            var vehiculo = $('#fVehiculo').val();
+
             var visibles = 0;
             $('.feed-card').each(function () {
-                var texto = $(this).data('busqueda') || '';
-                if (texto.indexOf(busqueda) !== -1) { $(this).show(); visibles++; }
-                else { $(this).hide(); }
+                var $c = $(this);
+                var ok = true;
+
+                if (busqueda && String($c.data('busqueda') || '').indexOf(busqueda) === -1) ok = false;
+
+                var fecha = String($c.data('fecha') || '');
+                if (ok && desde && (!fecha || fecha < desde)) ok = false;
+                if (ok && hasta && (!fecha || fecha > hasta)) ok = false;
+
+                if (ok && vehiculo && String($c.data('vehiculo')) !== String(vehiculo)) ok = false;
+
+                $c.toggle(ok);
+                if (ok) visibles++;
             });
+
             $('#noResultados').toggle(visibles === 0);
+            $('#badgeTotal').text(visibles + (visibles === 1 ? ' siniestro' : ' siniestros'));
+        }
+
+        /** Llena el selector de vehículo con los que realmente aparecen en el feed. */
+        function llenarFiltroVehiculos(lista) {
+            var vistos = {};
+            var $sel = $('#fVehiculo');
+            lista.forEach(function (s) {
+                var id = s.id_vehiculo;
+                if (!id || vistos[id]) return;
+                vistos[id] = true;
+                $sel.append($('<option>').val(id).text((s.placa || 'S/P') + ' - ' + (s.modelo || '')));
+            });
         }
 
         function verDetalle(id_siniestro) {
@@ -211,9 +282,12 @@ if ($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null) {
                     var fotosHtml = '';
                     if (Array.isArray(s.imagenes) && s.imagenes.length > 0) {
                         var items = s.imagenes.map(function (img, i) {
+                            // El respaldo NO apunta a img/sin_foto.png: ese archivo no
+                            // existe en el proyecto, así que la imagen de reemplazo
+                            // quedaba igual de rota. Se sustituye por un marcador propio.
                             return `<div class="carousel-item ${i === 0 ? 'active' : ''}">
                                 <img src="${img}" class="d-block w-100" style="max-height:280px;object-fit:contain;"
-                                     onerror="this.src='img/sin_foto.png'">
+                                     onerror="this.onerror=null; this.outerHTML=marcadorSinFoto();">
                             </div>`;
                         }).join('');
                         fotosHtml = `<div id="carruselDetalle" class="carousel slide" data-bs-ride="carousel">

--- a/siniestros.php
+++ b/siniestros.php
@@ -106,7 +106,7 @@
                         <h1 class="h5 mb-2 text-gray-800">Detalles del Automóvil</h1>
                         <div class="row mb-3">
                             <div class="col-lg-3 col-md-6 col-sm-6 col-12 mb-2">
-                                <label>Ubicación del vehículo:</label>
+                                <label>Ubicación actual del vehículo:</label>
                                 <select class="form-select" id="ubicacion" name="ubicacion" required onchange="toggleUbicacionOtro()">
                                     <option value="">Seleccione...</option>
                                     <option value="MESS">MESS</option>
@@ -176,9 +176,15 @@
             if (navigator.geolocation) {
                 navigator.geolocation.getCurrentPosition(
                     function (position) {
-                        const lat = position.coords.latitude.toFixed(6); 
-                        const lon = position.coords.longitude.toFixed(6); 
+                        const lat = position.coords.latitude.toFixed(6);
+                        const lon = position.coords.longitude.toFixed(6);
                         $("#coordenadas").val(`${lat}, ${lon}`); // Establecer las coordenadas en el campo
+                    },
+                    // El fallo se registra solo en consola, para diagnóstico. Al usuario no
+                    // se le muestra nada: el siniestro se puede registrar igual y un aviso
+                    // aquí solo estorbaría en un momento en el que ya tiene un problema.
+                    function (err) {
+                        console.warn('No se pudieron obtener las coordenadas del siniestro:', err && err.message);
                     }
                 );
             }

--- a/validar_recargas.php
+++ b/validar_recargas.php
@@ -1,0 +1,231 @@
+<?php
+session_start();
+require_once __DIR__ . '/includes/sesion_cookies.php';
+include 'conn.php';
+if ($_COOKIE['noEmpleado'] == '' || $_COOKIE['noEmpleado'] == null) {
+    echo '<script>window.location.assign("index")</script>';
+    exit;
+}
+
+// Guard de la vista. El endpoint valida por su cuenta; esto solo evita mostrar la
+// página a quien no tiene el acceso de consulta.
+$stmtAcc = $conn->prepare(
+    "SELECT 1 FROM mess_rrhh.accesos_especiales
+     WHERE noEmpleado = ? AND sistema = 'ctrlVehicular' AND opcion = 'verSolicitudesGas' AND estatus = 1
+     LIMIT 1"
+);
+$noEmpVista = intval($_COOKIE['noEmpleado']);
+$stmtAcc->bind_param("i", $noEmpVista);
+$stmtAcc->execute();
+$tieneAcceso = (bool) $stmtAcc->get_result()->fetch_assoc();
+$stmtAcc->close();
+if (!$tieneAcceso) {
+    echo '<script>window.location.assign("inicio")</script>';
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Control Vehicular - Recargas</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800&display=swap" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
+    <link href="css/mess-ds.css" rel="stylesheet">
+</head>
+<body id="page-top">
+    <div id="wrapper">
+        <?php include 'menu.php'; ?>
+        <div id="content-wrapper" class="d-flex flex-column">
+            <div id="content">
+                <?php include 'encabezado.php'; ?>
+                <div class="container-fluid">
+
+                    <div class="d-sm-flex align-items-center justify-content-between mb-3">
+                        <h1 class="h3 mb-0 text-black-800">Solicitudes de Recarga</h1>
+                        <span class="badge bg-secondary fs-6" id="badgeTotal"></span>
+                    </div>
+
+                    <ul class="nav nav-pills mb-3" id="tabsEstatus">
+                        <li class="nav-item"><button class="nav-link active" data-estatus="PENDIENTE">Pendientes <span class="badge bg-light text-dark ms-1" id="cntPENDIENTE">0</span></button></li>
+                        <li class="nav-item"><button class="nav-link" data-estatus="APROBADA">Aprobadas <span class="badge bg-light text-dark ms-1" id="cntAPROBADA">0</span></button></li>
+                        <li class="nav-item"><button class="nav-link" data-estatus="RECHAZADA">Rechazadas <span class="badge bg-light text-dark ms-1" id="cntRECHAZADA">0</span></button></li>
+                        <li class="nav-item"><button class="nav-link" data-estatus="">Todas</button></li>
+                    </ul>
+
+                    <div id="feedSolicitudes" class="row"></div>
+
+                    <div id="noResultados" class="text-center text-muted py-5" style="display:none;">
+                        <i class="fas fa-gas-pump fa-3x mb-3 d-block"></i>
+                        <p class="mb-0">No hay solicitudes en este estado.</p>
+                    </div>
+                </div>
+            </div>
+            <footer class="sticky-footer bg-white">
+                <div class="container my-auto"><div class="copyright text-center my-auto">
+                    <span>Copyright &copy; MESS <?php echo date("Y"); ?></span>
+                </div></div>
+            </footer>
+        </div>
+    </div>
+
+    <a class="scroll-to-top rounded" href="#page-top"><i class="fas fa-angle-up"></i></a>
+
+<script>
+    var solicitudes = [], puedeResolver = false, estatusActivo = 'PENDIENTE';
+
+    function esc(s) { return $('<div>').text(s == null ? '' : s).html(); }
+
+    function fmtFecha(f) {
+        if (!f) return '';
+        var p = String(f).split(/[- :]/);
+        return p[2] + '/' + p[1] + '/' + p[0] + (p[3] ? ' ' + p[3] + ':' + (p[4] || '00') : '');
+    }
+
+    function badgeEstatus(e) {
+        if (e === 'PENDIENTE') return '<span class="badge bg-warning text-dark">Pendiente</span>';
+        if (e === 'APROBADA')  return '<span class="badge bg-success">Aprobada</span>';
+        return '<span class="badge bg-danger">Rechazada</span>';
+    }
+
+    function pintar() {
+        var $c = $('#feedSolicitudes').empty();
+        var lista = estatusActivo ? solicitudes.filter(function (s) { return s.estatus === estatusActivo; }) : solicitudes;
+
+        $('#noResultados').toggle(lista.length === 0);
+        $('#badgeTotal').text(lista.length + (lista.length === 1 ? ' solicitud' : ' solicitudes'));
+
+        lista.forEach(function (s) {
+            var vehiculo = esc([s.marca, s.modelo].filter(Boolean).join(' ')) + ' — ' + esc(s.placa || 'S/P');
+
+            // km_recorrido puede venir null: el cálculo se descarta cuando la lectura del
+            // odómetro es incoherente, y es mejor no mostrar nada que una cifra falsa.
+            var km = (s.km_recorrido !== null && s.km_recorrido !== undefined)
+                ? Number(s.km_recorrido).toLocaleString('es-MX') + ' km'
+                : '<span class="text-muted">sin dato</span>';
+
+            var acciones = '';
+            if (puedeResolver && s.estatus === 'PENDIENTE') {
+                acciones =
+                    '<div class="d-flex gap-2 mt-3">'
+                    + '<button class="btn btn-success btn-sm flex-fill btn-resolver" data-id="' + s.id + '" data-res="APROBADA">'
+                    + '<i class="fas fa-check me-1"></i>Aprobar</button>'
+                    + '<button class="btn btn-outline-danger btn-sm flex-fill btn-resolver" data-id="' + s.id + '" data-res="RECHAZADA">'
+                    + '<i class="fas fa-xmark me-1"></i>Rechazar</button>'
+                    + '</div>';
+            }
+
+            var resuelta = '';
+            if (s.estatus !== 'PENDIENTE') {
+                resuelta = '<div class="small text-muted mt-2 border-top pt-2">'
+                    + '<i class="fas fa-user-check me-1"></i>' + esc(s.resolvio || 'S/R')
+                    + ' · ' + fmtFecha(s.fecha_resuelto)
+                    + (s.notas_resolucion ? '<div class="mt-1"><i class="fas fa-comment me-1"></i>' + esc(s.notas_resolucion) + '</div>' : '')
+                    + '</div>';
+            }
+
+            $c.append(
+                '<div class="col-lg-6 col-12 mb-3">'
+                + ' <div class="card shadow-sm h-100 border-0"><div class="card-body">'
+                + '  <div class="d-flex justify-content-between align-items-start mb-2">'
+                + '   <div><h5 class="mb-0 text-primary fw-bold"><i class="fas fa-car me-1"></i>' + esc(s.placa || 'S/P') + '</h5>'
+                + '    <small class="text-muted">' + vehiculo + '</small></div>'
+                + '   ' + badgeEstatus(s.estatus)
+                + '  </div>'
+                + '  <table class="table table-sm mb-0 small">'
+                + '   <tr><td class="text-muted">Solicitó</td><td class="text-end fw-semibold">' + esc(s.solicitante || 'S/R') + '</td></tr>'
+                + '   <tr><td class="text-muted">Fecha</td><td class="text-end">' + fmtFecha(s.fecha) + '</td></tr>'
+                + '   <tr><td class="text-muted">Saldo al solicitar</td><td class="text-end fw-semibold">$' + Number(s.saldo_solicitud || 0).toLocaleString('es-MX', {minimumFractionDigits: 2}) + '</td></tr>'
+                + '   <tr><td class="text-muted">Km del crédito</td><td class="text-end">' + km + '</td></tr>'
+                + '   <tr><td class="text-muted">Kilometraje</td><td class="text-end">' + (s.km_actual ? Number(s.km_actual).toLocaleString('es-MX') + ' km' : '<span class="text-muted">S/R</span>') + '</td></tr>'
+                + '  </table>'
+                + resuelta + acciones
+                + ' </div></div>'
+                + '</div>'
+            );
+        });
+    }
+
+    function contar() {
+        ['PENDIENTE', 'APROBADA', 'RECHAZADA'].forEach(function (e) {
+            $('#cnt' + e).text(solicitudes.filter(function (s) { return s.estatus === e; }).length);
+        });
+    }
+
+    function cargar() {
+        $('#feedSolicitudes').html('<div class="col-12 text-center py-5"><i class="fas fa-spinner fa-spin fa-2x text-primary"></i></div>');
+        $.ajax({
+            url: 'acciones_gas.php', method: 'POST', dataType: 'json',
+            data: { accion: 'consultarSolicitudesGas' }
+        }).done(function (resp) {
+            if (!resp || resp.status !== 'success') {
+                $('#feedSolicitudes').empty();
+                Swal.fire({ icon: 'error', title: 'Error', text: (resp && resp.message) ? resp.message : 'No se pudieron cargar las solicitudes.' });
+                return;
+            }
+            // Array.isArray antes de iterar: el endpoint devuelve un objeto de error
+            // cuando algo falla y recorrerlo rompe en silencio.
+            solicitudes  = Array.isArray(resp.solicitudes) ? resp.solicitudes : [];
+            puedeResolver = !!resp.puedeResolver;
+            contar();
+            pintar();
+        }).fail(function () {
+            $('#feedSolicitudes').html('<div class="col-12 text-center text-danger py-5"><i class="fas fa-exclamation-circle fa-2x"></i><p class="mt-2">Error al cargar.</p></div>');
+        });
+    }
+
+    $(document).ready(function () {
+        cargar();
+
+        $('#tabsEstatus button').on('click', function () {
+            $('#tabsEstatus button').removeClass('active');
+            $(this).addClass('active');
+            estatusActivo = $(this).data('estatus');
+            pintar();
+        });
+
+        $(document).on('click', '.btn-resolver', function () {
+            var id  = $(this).data('id');
+            var res = $(this).data('res');
+            var aprobar = (res === 'APROBADA');
+
+            Swal.fire({
+                icon: aprobar ? 'question' : 'warning',
+                title: aprobar ? '¿Aprobar la recarga?' : '¿Rechazar la solicitud?',
+                input: 'textarea',
+                inputLabel: 'Notas (opcional)',
+                inputPlaceholder: aprobar ? 'Monto autorizado, comentarios...' : 'Motivo del rechazo...',
+                showCancelButton: true,
+                confirmButtonText: aprobar ? 'Aprobar' : 'Rechazar',
+                cancelButtonText: 'Cancelar',
+                confirmButtonColor: aprobar ? '#1cc88a' : '#e74a3b'
+            }).then(function (r) {
+                if (!r.isConfirmed) return;
+                $.ajax({
+                    url: 'acciones_gas.php', method: 'POST', dataType: 'json',
+                    data: { accion: 'resolverSolicitudGas', id_solicitud: id, resolucion: res, notas: r.value || '' }
+                }).done(function (resp) {
+                    if (!resp || resp.status !== 'success') {
+                        Swal.fire({ icon: 'error', title: 'No se pudo resolver', text: (resp && resp.message) ? resp.message : 'Error del servidor.' });
+                        return;
+                    }
+                    Swal.fire({
+                        icon: 'success',
+                        title: aprobar ? 'Aprobada' : 'Rechazada',
+                        text: resp.notificado ? 'Se avisó al solicitante por correo.' : 'Resuelta. No se pudo enviar el correo al solicitante.',
+                        timer: 2500, timerProgressBar: true
+                    });
+                    cargar();
+                }).fail(function () {
+                    Swal.fire({ icon: 'error', title: 'Error', text: 'No se pudo resolver la solicitud.' });
+                });
+            });
+        });
+    });
+</script>
+</body>
+</html>

--- a/verActividades.php
+++ b/verActividades.php
@@ -60,7 +60,7 @@ if ($stmtVA) {
                 <div class="container-fluid">
                     <!-- Page Heading -->
                     <div class="d-sm-flex align-items-center justify-content-between mb-4">
-                        <h1 class="h3 mb-0 text-gray-800">Actividades de vehiculos</h1>
+                        <h1 class="h3 mb-0 text-gray-800">Actividades de Vehículos</h1>
                     </div>
                     <!-- Content Row -->
                     <div class="row">

--- a/ver_checkins.php
+++ b/ver_checkins.php
@@ -126,6 +126,29 @@ if (!$tieneAcceso) {
 
     <a class="scroll-to-top rounded" href="#page-top"><i class="fas fa-angle-up"></i></a>
 
+    <!-- Mapa de la ubicación del check-in. Se usa el embed de Google Maps, que no
+         requiere API key; el iframe se rellena al abrir para no cargar 691 mapas. -->
+    <div class="modal fade" id="modalMapa" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-lg modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header py-2">
+                    <h6 class="modal-title" id="modalMapaTitulo">Ubicación del check-in</h6>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+                </div>
+                <div class="modal-body p-0">
+                    <iframe id="mapaFrame" src="" style="border:0; width:100%; height:60vh;"
+                            loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+                </div>
+                <div class="modal-footer py-2">
+                    <span class="small text-muted me-auto" id="modalMapaCoords"></span>
+                    <a id="modalMapaAbrir" href="#" target="_blank" rel="noopener" class="btn btn-sm btn-outline-primary">
+                        <i class="fas fa-up-right-from-square me-1"></i> Abrir en Google Maps
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+
 <script>
     var filas = [];
 
@@ -175,8 +198,12 @@ if (!$tieneAcceso) {
                 : '<span class="text-muted">&mdash;</span>';
 
             // Sin coordenadas no se pinta nada: un enlace de mapa vacío solo estorba.
+            // El mapa se abre en un modal dentro de la misma vista, para no perder la
+            // tabla ni los filtros al consultar una ubicación.
             var ubic = f.coordenadas
-                ? '<a href="https://www.google.com/maps?q=' + encodeURIComponent(f.coordenadas) + '" target="_blank" rel="noopener" title="' + esc(f.coordenadas) + '"><i class="fas fa-map-marker-alt"></i></a>'
+                ? '<button type="button" class="btn btn-link btn-sm p-0 btn-mapa" data-coords="' + esc(f.coordenadas) + '"'
+                    + ' data-titulo="' + esc((f.placa || '') + ' · ' + fmtFecha(f.fecha_actividad)) + '"'
+                    + ' title="' + esc(f.coordenadas) + '"><i class="fas fa-map-marker-alt"></i></button>'
                 : '<span class="text-muted">&mdash;</span>';
 
             $tb.append(
@@ -185,7 +212,9 @@ if (!$tieneAcceso) {
                 '<td class="small">' + vehiculo + '</td>' +
                 '<td class="small">' + esc(f.usuario || 'S/R') + '</td>' +
                 '<td>' + badgeTipo(f) + '</td>' +
-                '<td class="text-end small">' + (f.km_actual ? Number(f.km_actual).toLocaleString('es-MX') : '') + '</td>' +
+                // Con la unidad explícita: junto a la columna de OT/OV el número solo no
+                // dejaba claro qué representaba.
+                '<td class="text-end small text-nowrap">' + (f.km_actual ? Number(f.km_actual).toLocaleString('es-MX') + ' km' : '') + '</td>' +
                 '<td class="small">' + esc(f.ot || '') + '</td>' +
                 '<td class="text-center">' + foto + '</td>' +
                 '<td class="text-center">' + ubic + '</td>' +

--- a/verifica_checkinVehiculo.php
+++ b/verifica_checkinVehiculo.php
@@ -62,7 +62,8 @@ if ($stmtAcc) {
                 ?>
 
                 <!-- Begin Page Content -->
-                <div class="container-fluid">                    
+                <div class="container-fluid">
+                    <h1 class="h3 mb-3 text-black-800">Consulta de Check List</h1>
                     <div class="row" name="DivVehiculosAsignados" id="DivVehiculosAsignados">
                         <div class="col-12">
                             <div class="table-responsive">


### PR DESCRIPTION
Checklist. Empezar uno nuevo sobrescribía el anterior: el guardado buscaba "el último borrador del vehículo" y "No, empezar de nuevo" no creaba nada ni vaciaba el formulario, así que se veían y se pisaban los datos del previo. El servidor ahora devuelve el id_checklist y el cliente lo reenvía. El avance se guarda solo al cambiar de apartado, en silencio, y cada foto viaja una sola vez: getFotoInfo renombra con timestamp, así que reenviarlas dejaría una copia por paso. upsertChecklistSeccion ya no pisa la columna foto cuando no recibe archivo ni ruta — antes cualquier guardado parcial borraba la referencia de una foto ya subida. Quitar una foto manda un centinela explícito. Los puntos del asistente distinguen tres estados (gris, amarillo sin foto, verde con foto) y el azul de "aquí estás" gana sobre el color de estado.

Anomalías. Vista nueva con los mismos filtros que el historial de siniestros. La tabla no guardaba coordenadas: se agrega la columna, el QR las captura al reportar (opcional, sin bloquear si el GPS falla) y el historial las muestra en un mapa embebido.

Recargas de gas. La solicitud solo mandaba un correo y no dejaba rastro: no se sabía cuántas había pendientes ni quién las resolvió. Se agrega la tabla solicitudes_gas y una vista de validación con estados pendiente/aprobada/rechazada. Consultar y resolver son permisos distintos: verSolicitudesGas para BI, Roger y Óscar; autorizaRecargaGas solo para Vico. Al resolver se avisa al solicitante por correo. El correo de solicitud ahora incluye los km recorridos con ese crédito, calculados desde la carga donde el monto vuelve a 4000; se usa la última lectura por fecha y no MAX(km_actual), porque hay dedazos en el odómetro que daban más de un millón de kilómetros, y se descartan resultados imposibles. El bloque además reutiliza enviarCorreoMess() en vez de repetir la configuración SMTP.

Siniestros. Cuatro filtros en el historial (desde, hasta, vehículo, texto) y la etiqueta pasa a "Ubicación actual del vehículo".

Títulos. Las cuatro vistas que no tenían encabezado ya lo tienen, con el mismo patrón que el resto.

Fotos. El respaldo onerror apuntaba a img/sin_foto.png, archivo que no existe en el proyecto, así que la imagen de reemplazo quedaba igual de rota. Se sustituye por un marcador propio en anomalías y siniestros.